### PR TITLE
winbtrfs-np: Add certificate before installing driver and use InfDefaultInstall

### DIFF
--- a/bucket/winbtrfs-np.json
+++ b/bucket/winbtrfs-np.json
@@ -3,14 +3,35 @@
     "description": "Btrfs filesystem driver.",
     "homepage": "https://github.com/maharmstone/btrfs",
     "license": "LGPL-3.0-or-later",
-    "notes": "Secure Boot may need to be disabled in the BIOS settings in the event of a signing error.",
+    "notes": [
+        "If you using Windows 10 and have Secure Boot enabled, you may have to make a registry change in order for the driver to be loaded.",
+        "See https://github.com/maharmstone/btrfs#secureboot."
+    ],
     "url": "https://github.com/maharmstone/btrfs/releases/download/v1.8/btrfs-1.8.zip",
     "hash": "eee00e1f9768cbdb939fd51a54e821dd8f3fc75c6c96e216a41d7e1a6144d0d4",
+    "pre_install": [
+        "if (-not $global) {",
+        "    Write-Host -Foreground Red \"$app should be installed globally.\"",
+        "    exit 1",
+        "}"
+    ],
     "installer": {
-        "script": "Invoke-ExternalCommand PnPUtil -ArgumentList @('/add-driver', \"$dir\\btrfs.inf\", '/install') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the installation.' } | Out-Null"
+        "script": [
+            "# Add cert first before installing driver",
+            "$cert = (Get-AuthenticodeSignature \"$dir\\btrfs.cat\").SignerCertificate",
+            "$checkCert = Get-ChildItem Cert:\\CurrentUser\\TrustedPublisher -Recurse | Where-Object { $_.Thumbprint -eq $cert.Thumbprint }",
+            "if (!($checkCert)) {",
+            "    Write-Host \"Cert not found, adding to trusted store...\"",
+            "    [System.IO.File]::WriteAllBytes(\"$dir\\MarkHarmstone.cer\", $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))",
+            "    certutil -addstore -f \"TrustedPublisher\" \"$dir\\MarkHarmstone.cer\"",
+            "    Remove-Item \"$dir\\MarkHarmstone.cer\"",
+            "}",
+            "",
+            "Invoke-ExternalCommand pnputil -ArgumentList @('/add-driver', \"$dir\\btrfs.inf\", '/install') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the installation.' } | Out-Null"
+        ]
     },
     "uninstaller": {
-        "script": "Invoke-ExternalCommand PnPUtil -ArgumentList @('/delete-driver', \"$dir\\btrfs.inf\", '/uninstall') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null"
+        "script": "Invoke-ExternalCommand pnputil -ArgumentList @('/delete-driver', \"$dir\\btrfs.inf\", '/uninstall') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null"
     },
     "checkver": "github",
     "autoupdate": {

--- a/bucket/winbtrfs-np.json
+++ b/bucket/winbtrfs-np.json
@@ -7,6 +7,7 @@
         "If you using Windows 10 and have Secure Boot enabled, you may have to make a registry change in order for the driver to be loaded.",
         "See https://github.com/maharmstone/btrfs#secureboot."
     ],
+    "depends": "extras/autohotkey",
     "url": "https://github.com/maharmstone/btrfs/releases/download/v1.8/btrfs-1.8.zip",
     "hash": "eee00e1f9768cbdb939fd51a54e821dd8f3fc75c6c96e216a41d7e1a6144d0d4",
     "pre_install": [
@@ -27,11 +28,13 @@
             "    Remove-Item \"$dir\\MarkHarmstone.cer\"",
             "}",
             "",
-            "Invoke-ExternalCommand pnputil -ArgumentList @('/add-driver', \"$dir\\btrfs.inf\", '/install') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the installation.' } | Out-Null"
+            "Write-Host \"Installing driver...\"",
+            "InfDefaultInstall \"$dir\\btrfs.inf\"",
+            "Start-Process -Wait autohotkey -ArgumentList \"$bucketsdir\\nonportable\\scripts\\$app\\no-reboot.ahk\""
         ]
     },
     "uninstaller": {
-        "script": "Invoke-ExternalCommand pnputil -ArgumentList @('/delete-driver', \"$dir\\btrfs.inf\", '/uninstall') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null"
+        "script": "Invoke-ExternalCommand pnputil -ArgumentList @('/delete-driver', \"$dir\\btrfs.inf\", '/uninstall', '/force') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null"
     },
     "checkver": "github",
     "autoupdate": {

--- a/scripts/winbtrfs-np/no-reboot.ahk
+++ b/scripts/winbtrfs-np/no-reboot.ahk
@@ -1,0 +1,8 @@
+#SingleInstance, force, NoEnv
+SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
+SetTitleMatchMode, RegEx
+
+WinWait, Microsoft Windows, Restart Now, 30
+hwnd := WinExist()
+Sleep 200
+ControlClick, Button2, ahk_id %hwnd% , , , , NA


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Continuation of https://github.com/TheRandomLabs/scoop-nonportable/pull/309
> Things added:
> 
> * Restrict to global install (because driver installs are system installs)
> * Update Secure Boot note
> * Ensure that the certificate is added first before installing the driver. This way, the driver popup will not appear when installing for the first time and will not require interaction.
> * Fix [I cannot see any btrfs partitions maharmstone/btrfs#342](https://github.com/maharmstone/btrfs/issues/342). Applied the same workaround from chocolatey by using InfDefaultInstall instead of pnputil and an autohotkey script to close the popup. This adds an `autohotkey` dependency to the manifest.



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
