### PR TITLE
peace-np: check for shortcut before removal

### DIFF
--- a/bucket/peace-np.json
+++ b/bucket/peace-np.json
@@ -36,7 +36,9 @@
             "$peace_exe = 'Peace' + $(If ($architecture -eq '64bit') {'64'} Else {''}) + '.exe'",
             "Move-Item -Force \"$dir\\download\" \"$config_path\\$peace_exe\" | Out-Null",
             "New-Item -ItemType SymbolicLink -Path \"$dir\\$peace_exe\" -Target \"$config_path\\$peace_exe\" | Out-Null",
-            "Remove-Item \"$([Environment]::GetFolderPath('Desktop'))\\Peace.lnk\""
+            "if (Test-Path \"$([Environment]::GetFolderPath('Desktop'))\\Peace.lnk\") {",
+            "    Remove-Item \"$([Environment]::GetFolderPath('Desktop'))\\Peace.lnk\"",
+            "}"
         ]
     },
     "uninstaller": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
When I last installed Peace via scoop there was an error due to the desktop shortcut not existing when it tried to remove it. The installation still completed successfully though the desktop shortcut was not created until after launching Peace.

So this simply checks if the shortcut is there before removing it.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
