### PR TITLE
icaros-np: remove registry modification

### DIFF
--- a/bucket/icaros-np.json
+++ b/bucket/icaros-np.json
@@ -20,7 +20,6 @@
         "    regsvr32 /s \"$dir\\64-bit\\IcarosPropertyHandler.dll\"",
         "}",
         "",
-        "if (!(Test-Path HKLM:\\SOFTWARE\\Icaros)) { reg add HKLM\\SOFTWARE\\Icaros /f /v \"Thumbnail Extensions\" /t REG_SZ /d \"3g2;3gp;3gp2;3gpp;amv;ape;asf;avi;bik;cb7;cbr;cbz;divx;dpg;dv;dvr-ms;epub;evo;f4v;flac;flv;hdmov;k3g;m1v;m2t;m2ts;m2v;m4b;m4p;m4v;mk3d;mka;mkv;mov;mp2v;mp4;mp4v;mpc;mpe;mpeg;mpg;mpv2;mpv4;mqv;mts;mxf;nsv;ofr;ofs;ogg;ogm;ogv;opus;qt;ram;rm;rmvb;skm;spx;swf;tak;tp;tpr;trp;ts;tta;vob;wav;webm;wm;wmv;wv;xvid\" | Out-Null }",
         "Stop-Process -Name explorer"
     ],
     "uninstaller": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Since v3.3.0 beta 1 the way filetypes are stored in the registry has changed.

From the [release notes](https://shark007.net/forum/Thread-New-Release-3-3-0-Beta-1):
>With this release I've changed the way Icaros' property settings are stored in the registry.
Some new features required Icaros to be able to detect what properties was available in a users
previously installed build, and that wasn't possible with the current setup.
>...
>Icaros will automatically generate this list if it does not already exist, during registration/unregistration.
The list is generated with default values for each filetype.

Therefore it's no longer necessary to set the default filetype registry key manually as it will be created automatically.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
