### PR TITLE
winfsp-np: Enable Developer option so that headers and libraries are installed

### DIFF
--- a/bucket/winfsp-np.json
+++ b/bucket/winfsp-np.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/billziss-gh/winfsp/releases/download/v1.11/winfsp-1.11.22176.msi#/setup.msi_",
     "hash": "861a81364ef835dbccd6f6564dc7d8bb8efc94e5759ba57ba49ed56f9f35ab46",
     "installer": {
-        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/qn') -RunAs | Out-Null"
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", 'ADDLOCAL=F.Developer', '/qn') -RunAs | Out-Null"
     },
     "uninstaller": {
         "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$dir\\setup.msi_\", '/qn') -RunAs | Out-Null"


### PR DESCRIPTION
As far as I know there is no easy related to this PR, aside from this PR itself.

While attempting to use winfsp-np I noticed that it did not include the header files and developer libraries in the default install. After a bit of exploration my part(recently started using Windows after 15+ years away) I figured out installer flags to add to make it install the Developer feature set. There are some other features, but I didn't want to enable them as they seemed to have more far reaching impact than just the addition of developer files.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
