### PR TITLE
winbtrfs-np: Use break instead of exit

### DIFF
--- a/bucket/winbtrfs-np.json
+++ b/bucket/winbtrfs-np.json
@@ -13,7 +13,7 @@
     "pre_install": [
         "if (-not $global) {",
         "    Write-Host -Foreground Red \"$app should be installed globally.\"",
-        "    exit 1",
+        "    break",
         "}"
     ],
     "installer": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Suggestion from https://github.com/ScoopInstaller/Nonportable/pull/22#issuecomment-1179668711

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
