### PR TITLE
iddsampledriver-ge9-np: Remove uninstall check on uninstaller

### DIFF
--- a/bucket/iddsampledriver-ge9-np.json
+++ b/bucket/iddsampledriver-ge9-np.json
@@ -42,7 +42,6 @@
     },
     "uninstaller": {
         "script": [
-            "if ($cmd -ne 'uninstall') { return }",
             "nefconw --remove-device-node --hardware-id ROOT\\iddsampledriver --class-guid 4d36e968-e325-11ce-bfc1-08002be10318",
             "if ($purge) {",
             "    Write-Host -Foreground Yellow \"Removing 'C:\\IddSampleDriver'\"",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

When updating, a duplicate device will appear in the device manager, so it is best to uninstall the existing driver first before installing the new one when upgrading.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
