### PR TITLE
lavfilters-np: Add version 0.76.1

### DIFF
--- a/bucket/lavfilters-np.json
+++ b/bucket/lavfilters-np.json
@@ -1,7 +1,7 @@
 {
-    "homepage": "https://1f0.de/",
-    "description": "Open-Source DirectShow Media Splitter and Decoders.",
     "version": "0.76.1",
+    "description": "Open-Source DirectShow Media Splitter and Decoders.",
+    "homepage": "https://1f0.de/",
     "license": {
         "identifier": "GPL-2.0-only",
         "url": "https://github.com/Nevcairiel/LAVFilters/blob/master/COPYING"

--- a/bucket/lavfilters-np.json
+++ b/bucket/lavfilters-np.json
@@ -1,0 +1,63 @@
+{
+    "homepage": "https://1f0.de/",
+    "description": "Open-Source DirectShow Media Splitter and Decoders.",
+    "version": "0.76.1",
+    "license": {
+        "identifier": "GPL-2.0-only",
+        "url": "https://github.com/Nevcairiel/LAVFilters/blob/master/COPYING"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Nevcairiel/LAVFilters/releases/download/0.76.1/LAVFilters-0.76.1-x64.zip",
+            "hash": "bf52325ba35dff7dd772bdfd8819206fb60ae6efa48f0f562e5e6daf3c07d8a4"
+        },
+        "32bit": {
+            "url": "https://github.com/Nevcairiel/LAVFilters/releases/download/0.76.1/LAVFilters-0.76.1-x86.zip",
+            "hash": "3973f6364c6b101353631025ed172dbaa28c2878c18fad45bcd98689aaf84594"
+        }
+    },
+    "depends": "sudo",
+    "installer": {
+        "script": [
+            "sudo \"$env:COMSPEC\" /c \"regsvr32 /s `\"$dir\\LAVAudio.ax`\" & regsvr32 /s `\"$dir\\LAVSplitter.ax`\" & regsvr32 /s `\"$dir\\LAVVideo.ax`\"\"",
+            "@('LAVAudio', 'LAVSplitter', 'LAVVideo') | %{",
+            "    $s = (New-Object -ComObject WScript.Shell).CreateShortcut(\"$dir\\$_.lnk\")",
+            "    $s.TargetPath = \"rundll32.exe\"",
+            "    $s.Arguments = \"`\"$dir\\$_.ax`\",OpenConfiguration\"",
+            "    $s.WorkingDirectory = \"$dir\"",
+            "    $s.IconLocation = \"$dir\\$_.ax\"",
+            "    $s.Save()",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": "sudo \"$env:COMSPEC\" /c \"regsvr32 /u /s `\"$dir\\LAVAudio.ax`\" & regsvr32 /u /s `\"$dir\\LAVSplitter.ax`\" & regsvr32 /u /s `\"$dir\\LAVVideo.ax`\"\""
+    },
+    "shortcuts": [
+        [
+            "LAVAudio.lnk",
+            "LAV Audio Configuration"
+        ],
+        [
+            "LAVSplitter.lnk",
+            "LAV Splitter Configuration"
+        ],
+        [
+            "LAVVideo.lnk",
+            "LAV Video Configuration"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Nevcairiel/LAVFilters"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Nevcairiel/LAVFilters/releases/download/$version/LAVFilters-$version-x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/Nevcairiel/LAVFilters/releases/download/$version/LAVFilters-$version-x86.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
### LAV Filters - ffmpeg based DirectShow Splitter and Decoders

LAV Filters are a set of DirectShow filters based on the libavformat and libavcodec libraries
from the ffmpeg project, which will allow you to play virtually any format in a DirectShow player.

https://github.com/Nevcairiel/LAVFilters

---

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
