### PR TITLE
spotx: Do not delete Spotify desktop shortcut

### DIFF
--- a/bucket/spotx-np.json
+++ b/bucket/spotx-np.json
@@ -10,8 +10,7 @@
             "# older versions of Powershell 5 requires BOM to recognize UTF8 scripts",
             "$cont = Get-Content \"$dir\\Install.ps1\" -Encoding utf8",
             "Set-Content \"$dir\\Install.ps1\" $cont -Encoding utf8",
-            "& \"$dir\\Install.ps1\" -confirm_uninstall_ms_spoti -confirm_spoti_recomended_over -podcasts_off -cache_off -block_update_on",
-            "Remove-Item \"$([Environment]::GetFolderPath('Desktop'))\\Spotify.lnk\""
+            "& \"$dir\\Install.ps1\" -confirm_uninstall_ms_spoti -confirm_spoti_recomended_over -podcasts_off -cache_off -block_update_on"
         ]
     },
     "uninstaller": {


### PR DESCRIPTION
Hi
You can tweak the script so that after installation the shortcut is not deleted from the desktop, since it is not very convenient for users to look for it elsewhere.