### PR TITLE
zerotier-np: Better address for automatic updates

### DIFF
--- a/bucket/zerotier-np.json
+++ b/bucket/zerotier-np.json
@@ -27,6 +27,6 @@
         "regex": "(?s)Latest version\\: <a.*?>([\\d.]+)</a>"
     },
     "autoupdate": {
-        "url": "https://download.zerotier.com/dist/ZeroTier%20One.msi#/setup.msi_"
+        "url": "https://download.zerotier.com/RELEASES/$version/dist/ZeroTierOne.msi#/setup.msi_"
     }
 }


### PR DESCRIPTION
The hash of the original download address changes frequently, causing frequent download or update failures.
Local test passed.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->



- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
