### PR TITLE
anki-np: Fix autoupdate

### DIFF
--- a/bucket/anki-np.json
+++ b/bucket/anki-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.1.49",
+    "version": "2.1.54",
     "description": "Powerful and intelligent flash cards",
     "homepage": "https://apps.ankiweb.net",
     "license": "AGPL-3.0-only",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ankitects/anki/releases/download/2.1.49/anki-2.1.49-windows.exe#/installer.exe",
-            "hash": "3c9764cb4746cfa4059633678b9dcdc0ae5754e61d99855cb0c40fa6bfd33f5e"
+            "url": "https://github.com/ankitects/anki/releases/download/2.1.54/anki-2.1.54-windows-qt6.exe#/installer.exe",
+            "hash": "f42ad7a5d8135e184350dcc7373f54f326a42960a65072424d39cca04bd702e4"
         }
     },
     "installer": {
@@ -29,13 +29,12 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/ankitects/anki/releases",
-        "regex": "anki-([\\d.]+)-windows\\.exe"
+        "github": "https://github.com/ankitects/anki"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ankitects/anki/releases/download/$version/anki-$version-windows.exe#/installer.exe"
+                "url": "https://github.com/ankitects/anki/releases/download/$version/anki-$version-windows-qt6.exe#/installer.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
Fixes Anki autoupdate which was broken since they implemented alternative versions for Qt versions, and updates it to the latest version.