### PR TITLE
stevedore-np: Add version 0.8.0

### DIFF
--- a/bucket/stevedore-np.json
+++ b/bucket/stevedore-np.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.8.0",
+    "description": "Docker distribution for Windows that Just Works",
+    "homepage": "https://github.com/slonopotamus/stevedore",
+    "license": "Apache-2.0",
+    "notes": [
+        "A restart may be required, at least on the first install.",
+        "Please run `sc start stevedored` as an administrator if `docker run` does not work."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/slonopotamus/stevedore/releases/download/0.8.0/stevedore-0.8.0-x86_64.msi#/setup.msi_",
+            "hash": "df218282307d7261d7ac2932af197a15939dacdca9bfefa14776f3ffcd316cf5"
+        }
+    },
+    "installer": {
+        "script": "Start-Process -Wait msiexec \"/i `\"$dir\\setup.msi_`\" /qn /norestart\" -Verb RunAs"
+    },
+    "uninstaller": {
+        "script": "Start-Process -Wait msiexec \"/x `\"$dir\\setup.msi_`\" /qn /norestart\" -Verb RunAs"
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/slonopotamus/stevedore/releases/download/$version/stevedore-$version-x86_64.msi#/setup.msi_"
+            }
+        }
+    }
+}

--- a/bucket/stevedore-np.json
+++ b/bucket/stevedore-np.json
@@ -1,6 +1,6 @@
 {
     "version": "0.8.0",
-    "description": "Docker distribution for Windows that Just Works",
+    "description": "Docker distribution that aims to provide a frictionless Docker experience on Windows",
     "homepage": "https://github.com/slonopotamus/stevedore",
     "license": "Apache-2.0",
     "notes": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Adds [stevedore](https://github.com/slonopotamus/stevedore) to the bucket.

Pretty much a straight, updated copy of TheRandomLabs/scoop-nonportable#296 (done with the original author's permission).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
