### PR TITLE
SpotX-np: Changing the repository link

### DIFF
--- a/bucket/spotx-np.json
+++ b/bucket/spotx-np.json
@@ -1,6 +1,5 @@
 {
     "version": "1.5-20221014-93e169",
-
     "description": "Modified spotify client. Blocks ads and updates, and more.",
     "homepage": "https://github.com/SpotX-CLI/SpotX-Win/",
     "license": "MIT",

--- a/bucket/spotx-np.json
+++ b/bucket/spotx-np.json
@@ -1,9 +1,9 @@
 {
     "version": "2019.1-beta6",
     "description": "Modified spotify client. Blocks ads and updates, and more.",
-    "homepage": "https://github.com/amd64fox/SpotX/",
+    "homepage": "https://github.com/SpotX-CLI/SpotX-Win/",
     "license": "MIT",
-    "url": "https://raw.githubusercontent.com/amd64fox/SpotX/main/Install.ps1",
+    "url": "https://raw.githubusercontent.com/SpotX-CLI/SpotX-Win/main/Install.ps1",
     "hash": "042340a8523f270b298fb1791c3b5d07cdc4b592974520f5bb8ec28d109a4990",
     "installer": {
         "script": [
@@ -19,14 +19,14 @@
     "checkver": {
         "script": [
             "# Using script to get version number from date, e.g. 6 Mar, 2019 -> 20190306",
-            "$url1 = 'https://api.github.com/repos/amd64fox/SpotX/releases/latest'",
+            "$url1 = 'https://api.github.com/repos/SpotX-CLI/SpotX-Win/releases/latest'",
             "$regex1 = 'tag/([\\d.]+)'",
             "$cont = $(Invoke-WebRequest $url1).Content",
             "if(!($cont -match $regex1)) { error \"Could match '$regex1' on '$url1'\"; return }",
             "$app_ver = $matches[1]",
             "",
-            "$url2 = 'https://github.com/amd64fox/SpotX/commits/main/Install.ps1'",
-            "$regex2 = '(?sm)Commits on ([\\w\\s,]+)</h2>.*?SpotX/commits/([0-9a-f]{6})'",
+            "$url2 = 'https://github.com/SpotX-CLI/SpotX-Win/commits/main/Install.ps1'",
+            "$regex2 = '(?sm)Commits on ([\\w\\s,]+)</h2>.*?SpotX-Win/commits/([0-9a-f]{6})'",
             "$cont = $(Invoke-WebRequest $url2).Content",
             "if(!($cont -match $regex2)) { error \"Could match '$regex2' on '$url2'\"; return }",
             "$update_date = $(Get-Date $matches[1]).ToString('yyyyMMdd')",
@@ -36,6 +36,6 @@
         "regex": "([\\w.-]+)"
     },
     "autoupdate": {
-        "url": "https://raw.githubusercontent.com/amd64fox/SpotX/main/Install.ps1"
+        "url": "https://raw.githubusercontent.com/SpotX-CLI/SpotX-Win/main/Install.ps1"
     }
 }

--- a/bucket/spotx-np.json
+++ b/bucket/spotx-np.json
@@ -1,10 +1,10 @@
 {
-    "version": "2019.1-beta6",
+    "version": "1.5-20221008-d5e523",
     "description": "Modified spotify client. Blocks ads and updates, and more.",
     "homepage": "https://github.com/SpotX-CLI/SpotX-Win/",
     "license": "MIT",
     "url": "https://raw.githubusercontent.com/SpotX-CLI/SpotX-Win/main/Install.ps1",
-    "hash": "042340a8523f270b298fb1791c3b5d07cdc4b592974520f5bb8ec28d109a4990",
+    "hash": "29c9f6cb0d9213928cdb0c58b5bf94472ff231d537fe0c90ce3aea6241271d27",
     "installer": {
         "script": [
             "# older versions of Powershell 5 requires BOM to recognize UTF8 scripts",


### PR DESCRIPTION
https://github.com/SpotX-CLI/SpotX-Win/issues/54
Since the repository link changed, it caused an incorrect version error.
Please check if everything is ok now
