### PR TITLE
virtualbox-np: Remove VBoxSDL.exe

### DIFF
--- a/bucket/virtualbox-np.json
+++ b/bucket/virtualbox-np.json
@@ -40,7 +40,6 @@
         "VBoxManage.exe",
         "VBoxNetDHCP.exe",
         "VBoxNetNAT.exe",
-        "VBoxSDL.exe",
         "VBoxSDS.exe",
         "VBoxSVC.exe",
         "VBoxTestOGL.exe",


### PR DESCRIPTION
Fixes "Can't shim 'VBoxSDL.exe': File doesn't exist." when trying to install current version of virtualbox-np.json

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
