### PR TITLE
virtualbox-with-extension-pack-np@7.0.0: Remove VBoxSDL.exe

### DIFF
--- a/bucket/virtualbox-with-extension-pack-np.json
+++ b/bucket/virtualbox-with-extension-pack-np.json
@@ -54,7 +54,6 @@
         "VBoxManage.exe",
         "VBoxNetDHCP.exe",
         "VBoxNetNAT.exe",
-        "VBoxSDL.exe",
         "VBoxSDS.exe",
         "VBoxSVC.exe",
         "VBoxTestOGL.exe",


### PR DESCRIPTION
Fixes "Can't shim 'VBoxSDL.exe': File doesn't exist." when trying to install current version of virtualbox-with-extension-pack-np.json

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
