### PR TITLE
mactype-np: Fix checkver and update to 2021.1-rc1

### DIFF
--- a/bucket/mactype-np.json
+++ b/bucket/mactype-np.json
@@ -1,6 +1,6 @@
 {
     "##": "The MacType installer is created with AdvancedInstaller.",
-    "version": "2019.1-beta6",
+    "version": "2021.1-rc1",
     "description": "Provides better font rendering for Windows.",
     "homepage": "https://mactype.net",
     "license": "GPL-3.0-or-later",
@@ -12,8 +12,8 @@
         "- Run in Service Mode (recommended)",
         "- Add `HookChildProcesses=0` to profile; see: https://github.com/snowie2000/mactype/wiki/HookChildProcesses"
     ],
-    "url": "https://github.com/snowie2000/mactype/releases/download/2019.1-beta6/MacTypeInstaller_2019.1-beta6.exe",
-    "hash": "d4d84bbb0d67480ac9c19d9f60874a496c84c54852e12f6b85e1c8ccb8c123ed",
+    "url": "https://github.com/snowie2000/mactype/releases/download/2021.1-rc1/MacTypeInstaller_2021.1-rc1.exe",
+    "hash": "3a73d19d4940b6308d07f1eb19a9b6db007423f3d2ebba1216f2df224a8b01f5",
     "innosetup": true,
     "uninstaller": {
         "script": [

--- a/bucket/mactype-np.json
+++ b/bucket/mactype-np.json
@@ -45,10 +45,11 @@
         "MacType.ini"
     ],
     "checkver": {
-        "url": "https://github.com/snowie2000/mactype/releases",
-        "regex": "download/([\\w.-]+)/(?<filename>MacTypeInstaller_[\\w._-]+\\.exe)"
+        "url": "https://api.github.com/repos/snowie2000/mactype/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "([\\w.-]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/snowie2000/mactype/releases/download/$version/$matchFilename"
+        "url": "https://github.com/snowie2000/mactype/releases/download/$version/MacTypeInstaller_$version.exe"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- Changed `checkver` to get the proper tag from the github api
- Reverted the manifest to 2021.1-rc1
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #82 
<!-- or -->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
