### PR TITLE
teracopy-np: Fix tests

### DIFF
--- a/bucket/teracopy-np.json
+++ b/bucket/teracopy-np.json
@@ -1,10 +1,10 @@
 {
-    "version": "3.9.2",
+    "version": "3.9.7",
     "description": "Utility for copying files.",
     "homepage": "https://www.codesector.com/teracopy",
     "license": "Freeware",
     "url": "http://www.codesector.com/files/teracopy.exe",
-    "hash": "e2dfc14c3b143e1d8d98305bf118651e433d053a437e13f4f5c463bede692ac5",
+    "hash": "5f7b796e4edd366c9c5a97ae65cf1722c3152e3bbdca593c593622b35372e81f",
     "installer": {
         "file": "teracopy.exe",
         "args": [

--- a/bucket/teracopy-np.json
+++ b/bucket/teracopy-np.json
@@ -8,8 +8,8 @@
     "installer": {
         "file": "teracopy.exe",
         "args": [
-        	"/qn",
-        	"/passive"
+            "/qn",
+            "/passive"
         ]
     },
     "uninstaller": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fixes test failures in my other PR https://github.com/ScoopInstaller/Nonportable/actions/runs/3536293824/jobs/5935195181#step:4:29
```
Error: [-] any leading whitespace consists only of spaces (excepting makefiles) 39ms (37ms|2ms)
Message
  RuntimeException: The following 2 lines contain TABs within leading whitespace: 
  File: D:\a\Nonportable\Nonportable\my_bucket\bucket\teracopy-np.json, Line: 11
  File: D:\a\Nonportable\Nonportable\my_bucket\bucket\teracopy-np.json, Line: 12
  at <ScriptBlock>, D:\a\Nonportable\Nonportable\scoop_core\test\Scoop-00File.Tests.ps1:185
```
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


<!-- or -->
Relates to #99

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
