### PR TITLE
spotx-np: Fix checkver script

### DIFF
--- a/bucket/spotx-np.json
+++ b/bucket/spotx-np.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.7-20230101-3a2b64",
+    "version": "1.7-20230117-eb5683",
     "description": "Modified spotify client. Blocks ads and updates, and more.",
     "homepage": "https://github.com/SpotX-CLI/SpotX-Win/",
     "license": "MIT",
     "url": "https://raw.githubusercontent.com/SpotX-CLI/SpotX-Win/main/Install.ps1",
-    "hash": "897c73278e5e7709e748200fba35083ce57b728955d97eef629e943331cd5a94",
+    "hash": "e94fa9b7d196f3335571cd630ccc865467904bbbad04f32260fb9244f82cca90",
     "installer": {
         "script": [
             "# older versions of Powershell 5 requires BOM to recognize UTF8 scripts",
@@ -36,7 +36,6 @@
             "    Write-Output \"$app_ver-$update_date-$commit_sha\"",
             "}",
             "catch { error $_.Exception.Message; throw }"
-
         ],
         "regex": "([\\w.-]+)"
     },

--- a/bucket/spotx-np.json
+++ b/bucket/spotx-np.json
@@ -18,20 +18,22 @@
     },
     "checkver": {
         "script": [
-            "# Using script to get version number from date, e.g. 6 Mar, 2019 -> 20190306",
-            "$url1 = 'https://api.github.com/repos/SpotX-CLI/SpotX-Win/releases/latest'",
-            "$regex1 = 'tag/([\\d.]+)'",
-            "$cont = $(Invoke-WebRequest $url1).Content",
-            "if(!($cont -match $regex1)) { error \"Could match '$regex1' on '$url1'\"; return }",
-            "$app_ver = $matches[1]",
-            "",
-            "$url2 = 'https://github.com/SpotX-CLI/SpotX-Win/commits/main/Install.ps1'",
-            "$regex2 = '(?sm)Commits on ([\\w\\s,]+)</h2>.*?SpotX-Win/commits/([0-9a-f]{6})'",
-            "$cont = $(Invoke-WebRequest $url2).Content",
-            "if(!($cont -match $regex2)) { error \"Could match '$regex2' on '$url2'\"; return }",
-            "$update_date = $(Get-Date $matches[1]).ToString('yyyyMMdd')",
-            "$commit_sha = $matches[2]",
-            "Write-Output \"$app_ver-$update_date-$commit_sha\""
+            "try {",
+            "    $url1 = 'https://api.github.com/repos/SpotX-CLI/SpotX-Win/releases/latest'",
+            "    $cont = $(Invoke-WebRequest $url1).Content | ConvertFrom-Json",
+            "    if(!($cont.tag_name)) { error \"Tag name not found in '$url1'\"; throw }",
+            "    $app_ver = $cont.tag_name",
+            "    $url2 = 'https://api.github.com/repos/SpotX-CLI/SpotX-Win/commits?path=Install.ps1&per_page=1'",
+            "    $cont2 = $(Invoke-WebRequest $url2).Content | ConvertFrom-Json",
+            "    if(!($cont2.commit.committer.date)) { error \"Commit date not found in '$url2'\"; throw }",
+            "    # Using script to get version number from date, e.g. 6 Mar, 2019 -> 20190306",
+            "    $update_date = $(Get-Date $cont2.commit.committer.date).ToString('yyyyMMdd')",
+            "    if(!($cont2.sha)) { error \"Commit hash not found in '$url2'\"; throw }",
+            "    $commit_sha = $($cont2.sha).Substring(0, 6)",
+            "    Write-Output \"$app_ver-$update_date-$commit_sha\"",
+            "}",
+            "catch { error $_.Exception.Message; throw }"
+
         ],
         "regex": "([\\w.-]+)"
     },

--- a/bucket/spotx-np.json
+++ b/bucket/spotx-np.json
@@ -19,12 +19,15 @@
     "checkver": {
         "script": [
             "try {",
+            "    $auth = Get-GitHubToken",
+            "    $head = @{}",
+            "    if($auth) { $head = @{'Authorization' = \"token $auth\"} }",
             "    $url1 = 'https://api.github.com/repos/SpotX-CLI/SpotX-Win/releases/latest'",
-            "    $cont = $(Invoke-WebRequest $url1).Content | ConvertFrom-Json",
+            "    $cont = $(Invoke-WebRequest -Headers $head $url1).Content | ConvertFrom-Json",
             "    if(!($cont.tag_name)) { error \"Tag name not found in '$url1'\"; throw }",
             "    $app_ver = $cont.tag_name",
             "    $url2 = 'https://api.github.com/repos/SpotX-CLI/SpotX-Win/commits?path=Install.ps1&per_page=1'",
-            "    $cont2 = $(Invoke-WebRequest $url2).Content | ConvertFrom-Json",
+            "    $cont2 = $(Invoke-WebRequest -Headers $head $url2).Content | ConvertFrom-Json",
             "    if(!($cont2.commit.committer.date)) { error \"Commit date not found in '$url2'\"; throw }",
             "    # Using script to get version number from date, e.g. 6 Mar, 2019 -> 20190306",
             "    $update_date = $(Get-Date $cont2.commit.committer.date).ToString('yyyyMMdd')",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The manifest has been updated by the excavator recently with wrong version numbers as seen here https://github.com/ScoopInstaller/Nonportable/commits/master/bucket/spotx-np.json

I made a few changes to the script in an attempt to prevent this:
- switched the second url to use the api as well
- better error handling
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
