### PR TITLE
winbtrfs-np: Fix installation, remove `nefcon` dependency

### DIFF
--- a/bucket/winbtrfs-np.json
+++ b/bucket/winbtrfs-np.json
@@ -29,13 +29,14 @@
             "}",
             "",
             "Write-Host \"Installing driver...\"",
-            "Invoke-ExternalCommand nefconw -ArgumentList @('--inf-default-install', '--inf-path', \"$dir\\btrfs.inf\") -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null"
+            "Invoke-ExternalCommand nefconw -ArgumentList @('--install-driver', '--inf-path', \"$dir\\btrfs.inf\") -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null"
         ]
     },
     "uninstaller": {
         "script": [
             "if ($cmd -ne 'uninstall') { return }",
             "Invoke-ExternalCommand nefconw -ArgumentList @('--remove-device-node', '--hardware-id', 'ROOT\\btrfs', '--class-guid', '71a27cdd-812a-11d0-bec7-08002be2092f') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null",
+            "nefconw --uninstall-driver --inf-path \"$dir\\btrfs.inf\"",
             "nefconw --remove-driver-service --service-name btrfs"
         ]
     },

--- a/bucket/winbtrfs-np.json
+++ b/bucket/winbtrfs-np.json
@@ -7,7 +7,6 @@
         "If you using Windows 10 and have Secure Boot enabled, you may have to make a registry change in order for the driver to be loaded.",
         "See https://github.com/maharmstone/btrfs#secureboot."
     ],
-    "depends": "extras/nefcon",
     "url": "https://github.com/maharmstone/btrfs/releases/download/v1.8.2/btrfs-1.8.2.zip",
     "hash": "5672da6ba0df205fc8b7732f5caf6594065ad6fad7726f8c029d7a6609f47771",
     "pre_install": [
@@ -29,15 +28,16 @@
             "}",
             "",
             "Write-Host \"Installing driver...\"",
-            "Invoke-ExternalCommand nefconw -ArgumentList @('--install-driver', '--inf-path', \"$dir\\btrfs.inf\") -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null"
+            "Invoke-ExternalCommand pnputil -ArgumentList @('/add-driver', \"$dir\\btrfs.inf\", '/install') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the installation.' } | Out-Null"
         ]
     },
     "uninstaller": {
         "script": [
             "if ($cmd -ne 'uninstall') { return }",
-            "Invoke-ExternalCommand nefconw -ArgumentList @('--remove-device-node', '--hardware-id', 'ROOT\\btrfs', '--class-guid', '71a27cdd-812a-11d0-bec7-08002be2092f') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null",
-            "nefconw --uninstall-driver --inf-path \"$dir\\btrfs.inf\"",
-            "nefconw --remove-driver-service --service-name btrfs"
+            "Invoke-ExternalCommand pnputil -ArgumentList @('/remove-device', 'ROOT\\btrfs\\0000') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null",
+            "pnputil /delete-driver \"$dir\\btrfs.inf\" /uninstall | Out-Null",
+            "pnputil /delete-driver \"$dir\\btrfs-vol.inf\" /uninstall | Out-Null",
+            "sc delete btrfs | Out-Null"
         ]
     },
     "checkver": "github",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

As of 1.8.2, normal pnputil installation works now.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
