### PR TITLE
Fix Nvidia display driver packages

### DIFF
--- a/bucket/nvidia-display-driver-dch-np.json
+++ b/bucket/nvidia-display-driver-dch-np.json
@@ -48,13 +48,13 @@
         ]
     },
     "checkver": {
-        "url": "https://www.nvidia.com/Download/processFind.aspx?psid=95&pfid=694&osid=19&lid=1",
-        "regex": ">([\\d.]{6})<"
+        "url": "https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&psid=98&osID=57&languageCode=1033&beta=0&isWHQL=1&dltype=-1&dch=1&upCRD=0&sort1=0&numberOfResults=1",
+        "regex": "\"Version\"\\s?:\\s?\"(?<version>[\\d.]+)\".*\"DownloadURL\"\\s?:\\s?\"https://us.download.nvidia.com/(?<path>[^\"]*)\""
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://us.download.nvidia.com/Windows/$version/$version-desktop-win10-64bit-international-dch-whql.exe#/dl.7z"
+                "url": "https://us.download.nvidia.com/$matchPath#/dl.7z_"
             }
         }
     }

--- a/bucket/nvidia-display-driver-dch-np.json
+++ b/bucket/nvidia-display-driver-dch-np.json
@@ -1,6 +1,6 @@
 {
     "version": "528.24",
-    "description": "NVIDIA display driver (Declarative Componentized Hardware version).",
+    "description": "NVIDIA display driver (Declarative Componentized Hardware version). DCH drivers are installed on most new desktop and mobile workstation systems.",
     "homepage": "https://www.nvidia.com/Download/index.aspx",
     "license": "Freeware",
     "notes": [

--- a/bucket/nvidia-display-driver-dch-np.json
+++ b/bucket/nvidia-display-driver-dch-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "471.41",
+    "version": "528.24",
     "description": "NVIDIA display driver.",
     "homepage": "https://www.nvidia.com/Download/index.aspx",
     "license": "Freeware",
@@ -12,8 +12,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://us.download.nvidia.com/Windows/471.41/471.41-desktop-win10-64bit-international-dch-whql.exe#/dl.7z",
-            "hash": "e0a6c5fad2a1476c8d9f1438c13111794b5d759a6efdec54bea3cf199cb1b91f"
+            "url": "https://us.download.nvidia.com/Windows/528.24/528.24-desktop-win10-win11-64bit-international-dch-whql.exe#/dl.7z",
+            "hash": "3dc4dc8d2f7ab3ea2d54c6c52ff2db6b1ee56f1572dbf7d8bba5bcac3455c234"
         }
     },
     "installer": {
@@ -54,7 +54,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://us.download.nvidia.com/$matchPath#/dl.7z_"
+                "url": "https://us.download.nvidia.com/$matchPath#/dl.7z"
             }
         }
     }

--- a/bucket/nvidia-display-driver-dch-np.json
+++ b/bucket/nvidia-display-driver-dch-np.json
@@ -1,6 +1,6 @@
 {
     "version": "528.24",
-    "description": "NVIDIA display driver.",
+    "description": "NVIDIA display driver (Declarative Componentized Hardware version).",
     "homepage": "https://www.nvidia.com/Download/index.aspx",
     "license": "Freeware",
     "notes": [

--- a/bucket/nvidia-display-driver-dch-np.json
+++ b/bucket/nvidia-display-driver-dch-np.json
@@ -12,17 +12,18 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://us.download.nvidia.com/Windows/528.24/528.24-desktop-win10-win11-64bit-international-dch-whql.exe#/dl.7z",
+            "url": "https://us.download.nvidia.com/Windows/528.24/528.24-desktop-win10-win11-64bit-international-dch-whql.exe#/dl.7z_",
             "hash": "3dc4dc8d2f7ab3ea2d54c6c52ff2db6b1ee56f1572dbf7d8bba5bcac3455c234"
         }
     },
     "installer": {
         "script": [
+            "if(!(is_admin)) { error 'This package requires admin rights to install'; break }",
+            "if ([environment]::OSVersion.Version.Major -lt 10) { error 'This package requires Windows 10/11 to install'; break }",
             "$service_disabled = (Get-CimInstance win32_service -Filter \"name='NVDisplay.ContainerLocalSystem'\").StartMode -eq 'Disabled'",
             "",
-            "New-Item \"$dir\\extract\" -ItemType Directory | Out-Null",
-            "Move-Item \"$dir\\*\" -Exclude \"extract\" -Destination \"$dir\\extract\"",
-            "New-Item \"$dir\\setup\" -ItemType Directory | Out-Null",
+            "New-Item \"$dir\\extract\", \"$dir\\setup\" -ItemType Directory | Out-Null",
+            "Expand-7zipArchive \"$dir\\dl.7z_\" \"$dir\\extract\" -Removal | Out-Null",
             "# Move everything we want",
             "Move-Item \"$dir\\extract\\Display.Driver\" -Destination \"$dir\\setup\"",
             "Move-Item \"$dir\\extract\\Display.Optimus\" -Destination \"$dir\\setup\"",
@@ -43,8 +44,7 @@
             "    Start-Process -Wait \"$dir\\setup\\setup.exe\" \"-s -noreboot\" -Verb RunAs",
             "}",
             "",
-            "Remove-Item -Recurse \"$dir\\extract\"",
-            "Remove-Item -Recurse \"$dir\\setup\""
+            "Remove-Item \"$dir\\extract\", \"$dir\\setup\" -Force -Recurse"
         ]
     },
     "checkver": {
@@ -54,7 +54,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://us.download.nvidia.com/$matchPath#/dl.7z"
+                "url": "https://us.download.nvidia.com/$matchPath#/dl.7z_"
             }
         }
     }

--- a/bucket/nvidia-display-driver-np.json
+++ b/bucket/nvidia-display-driver-np.json
@@ -7,7 +7,7 @@
         "osid: operating system ID, see https://www.nvidia.com/Download/API/lookupValueSearch.aspx?TypeID=4",
         "lid: language ID (US English == 1), see https://www.nvidia.com/Download/API/lookupValueSearch.aspx?TypeID=5"
     ],
-    "version": "472.12",
+    "version": "528.24",
     "description": "NVIDIA display driver",
     "homepage": "https://www.nvidia.com/Download/index.aspx",
     "license": {
@@ -23,8 +23,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://us.download.nvidia.com/Windows/472.12/472.12-desktop-win10-win11-64bit-international-whql.exe#/dl.7z_",
-            "hash": "95d8dc470e8f1352b4dbc3b38aefeb5cbbba024826a0541a9f88501b642d81d3"
+            "url": "https://us.download.nvidia.com/Windows/528.24/528.24-desktop-win10-win11-64bit-international-dch-whql.exe#/dl.7z_",
+            "hash": "3dc4dc8d2f7ab3ea2d54c6c52ff2db6b1ee56f1572dbf7d8bba5bcac3455c234"
         }
     },
     "installer": {
@@ -59,13 +59,13 @@
         ]
     },
     "checkver": {
-        "url": "https://www.nvidia.com/Download/processFind.aspx?osid=135&psid=101&lid=1",
-        "regex": "(?sm)GeForce Game Ready Driver.*?(\\d{3}\\.\\d{2})"
+        "url": "https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&psid=98&osID=57&languageCode=1033&beta=0&isWHQL=1&dltype=-1&dch=1&upCRD=0&sort1=0&numberOfResults=1",
+        "regex": "\"Version\"\\s?:\\s?\"(?<version>[\\d.]+)\".*\"DownloadURL\"\\s?:\\s?\"https://us.download.nvidia.com/(?<path>[^\"]*)\""
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://us.download.nvidia.com/Windows/$version/$version-desktop-win10-win11-64bit-international-whql.exe#/dl.7z_"
+                "url": "https://us.download.nvidia.com/$matchPath#/dl.7z_"
             }
         }
     }

--- a/bucket/nvidia-display-driver-np.json
+++ b/bucket/nvidia-display-driver-np.json
@@ -7,8 +7,8 @@
         "osid: operating system ID, see https://www.nvidia.com/Download/API/lookupValueSearch.aspx?TypeID=4",
         "lid: language ID (US English == 1), see https://www.nvidia.com/Download/API/lookupValueSearch.aspx?TypeID=5"
     ],
-    "version": "528.24",
-    "description": "NVIDIA display driver (standard version).",
+    "version": "472.12",
+    "description": "NVIDIA display driver (Standard version). \"Standard\" refers to driver packages that predate the DCH driver design paradigm. Standard drivers are for those who have not yet transitioned to contemporary DCH drivers, or require these drivers to support older products.",
     "homepage": "https://www.nvidia.com/Download/index.aspx",
     "license": {
         "identifier": "Freeware",
@@ -23,8 +23,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://us.download.nvidia.com/Windows/528.24/528.24-desktop-win10-win11-64bit-international-dch-whql.exe#/dl.7z_",
-            "hash": "3dc4dc8d2f7ab3ea2d54c6c52ff2db6b1ee56f1572dbf7d8bba5bcac3455c234"
+            "url": "https://us.download.nvidia.com/Windows/472.12/472.12-desktop-win10-win11-64bit-international-whql.exe#/dl.7z_",
+            "hash": "95d8dc470e8f1352b4dbc3b38aefeb5cbbba024826a0541a9f88501b642d81d3"
         }
     },
     "installer": {
@@ -59,7 +59,7 @@
         ]
     },
     "checkver": {
-        "url": "https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&psid=98&osID=57&languageCode=1033&beta=0&isWHQL=1&dltype=-1&dch=1&upCRD=0&sort1=0&numberOfResults=1",
+        "url": "https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&psid=98&osID=57&languageCode=1033&beta=0&isWHQL=1&dltype=-1&dch=0&upCRD=0&sort1=0&numberOfResults=1",
         "regex": "\"Version\"\\s?:\\s?\"(?<version>[\\d.]+)\".*\"DownloadURL\"\\s?:\\s?\"https://us.download.nvidia.com/(?<path>[^\"]*)\""
     },
     "autoupdate": {

--- a/bucket/nvidia-display-driver-np.json
+++ b/bucket/nvidia-display-driver-np.json
@@ -8,7 +8,7 @@
         "lid: language ID (US English == 1), see https://www.nvidia.com/Download/API/lookupValueSearch.aspx?TypeID=5"
     ],
     "version": "528.24",
-    "description": "NVIDIA display driver",
+    "description": "NVIDIA display driver (standard version).",
     "homepage": "https://www.nvidia.com/Download/index.aspx",
     "license": {
         "identifier": "Freeware",

--- a/bucket/nvidia-display-driver-np.json
+++ b/bucket/nvidia-display-driver-np.json
@@ -23,7 +23,7 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://us.download.nvidia.com/Windows/528.24/528.24-desktop-win10-win11-64bit-international-dch-whql.exe#/dl.7z",
+            "url": "https://us.download.nvidia.com/Windows/528.24/528.24-desktop-win10-win11-64bit-international-dch-whql.exe#/dl.7z_",
             "hash": "3dc4dc8d2f7ab3ea2d54c6c52ff2db6b1ee56f1572dbf7d8bba5bcac3455c234"
         }
     },
@@ -65,7 +65,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://us.download.nvidia.com/$matchPath#/dl.7z"
+                "url": "https://us.download.nvidia.com/$matchPath#/dl.7z_"
             }
         }
     }

--- a/bucket/nvidia-display-driver-np.json
+++ b/bucket/nvidia-display-driver-np.json
@@ -23,7 +23,7 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://us.download.nvidia.com/Windows/528.24/528.24-desktop-win10-win11-64bit-international-dch-whql.exe#/dl.7z_",
+            "url": "https://us.download.nvidia.com/Windows/528.24/528.24-desktop-win10-win11-64bit-international-dch-whql.exe#/dl.7z",
             "hash": "3dc4dc8d2f7ab3ea2d54c6c52ff2db6b1ee56f1572dbf7d8bba5bcac3455c234"
         }
     },
@@ -65,7 +65,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://us.download.nvidia.com/$matchPath#/dl.7z_"
+                "url": "https://us.download.nvidia.com/$matchPath#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Resolves #45 

I've been running these auto-update instructions in my scoop bucket for a bit. https://github.com/scowalt/scoop-apps/blob/main/bucket/geforce-game-ready-driver.json

I updated the path to reflect the `dl.7z` logic.

- [x] Test `bucket\nvidia-display-driver-np.json` installation
- [x] Test `bucket\nvidia-display-driver-dch-np.json` installation