### PR TITLE
portmaster-np: Change `checkver` to be more accurate

### DIFF
--- a/bucket/portmaster-np.json
+++ b/bucket/portmaster-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.7",
+    "version": "1.0.0",
     "homepage": "https://safing.io/",
     "description": "An open-source application firewall that allows for monitoring of network activity, blocking system-wide trackers and ads, aswell as enforcing system-wide DNS-over-HTTPS and DNS-over-TLS.",
     "license": "AGPL-3.0",
@@ -26,7 +26,7 @@
     ],
     "post_uninstall": "if ($cmd -eq 'uninstall') { Write-Host 'Please restart your computer to uninstall Portmaster properly' -F 'Red' }",
     "checkver": {
-        "github": "https://github.com/safing/portmaster"
+        "github": "https://github.com/safing/portmaster-packaging"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/portmaster-np.json
+++ b/bucket/portmaster-np.json
@@ -14,14 +14,14 @@
         "if (!(is_admin)) { throw 'Administrator privileges are required' }",
         "Write-Host \"Please wait for Portmaster to $cmd. Do not cancel this script!\" -F 'Yellow'",
         "Start-Process \"$dir\\portmaster-installer.exe\" -Verb RunAs -ArgumentList '/S' -Wait; Remove-Item \"$dir\\portmaster-installer.exe\"; Start-Sleep -Seconds 4",
-        "Copy-item \"$persist_dir\\*\" \"$env:ProgramData\\Safing\\Portmaster\\*\" -Recurse -Force -ErrorAction 'SilentlyContinue'",
+        "Copy-item \"$persist_dir\\*\" \"$env:ProgramData\\Safing\\Portmaster\" -Recurse -Force -ErrorAction 'SilentlyContinue'",
         "if ($cmd -eq 'update') { Stop-Process -Name @('portmaster-start', 'portmaster-core_v*', 'portmaster-notifier_v*') -Force -ErrorAction 'SilentlyContinue'}"
     ],
     "post_install": "if ($cmd -eq 'install') { Write-Host 'Please restart your computer for Portmaster to install properly' -F 'Red' }",
     "pre_uninstall": [
         "if (!(is_admin)) { throw 'Administrator privileges are required' }",
         "Write-Host \"Please wait for Portmaster to $cmd. Do not cancel this script!\" -F 'Yellow'",
-        "Copy-item \"$env:ProgramData\\Safing\\Portmaster\\*\" \"$persist_dir\\*\" -Include @('config.json', 'databases', 'logs') -Recurse -Force -ErrorAction 'SilentlyContinue'; Start-Sleep -Seconds 4",
+        "Copy-item \"$env:ProgramData\\Safing\\Portmaster\\*\" \"$persist_dir\" -Include @('config.json', 'databases', 'logs') -Recurse -Force -ErrorAction 'SilentlyContinue'; Start-Sleep -Seconds 4",
         "if ($cmd -eq 'uninstall') { Start-Process \"$env:ProgramData\\Safing\\Portmaster\\portmaster-uninstaller.exe\" -Verb RunAs -ArgumentList '/S' -Wait; Start-Sleep -Seconds 5 }"
     ],
     "post_uninstall": "if ($cmd -eq 'uninstall') { Write-Host 'Please restart your computer to uninstall Portmaster properly' -F 'Red' }",

--- a/bucket/portmaster-np.json
+++ b/bucket/portmaster-np.json
@@ -14,14 +14,14 @@
         "if (!(is_admin)) { throw 'Administrator privileges are required' }",
         "Write-Host \"Please wait for Portmaster to $cmd. Do not cancel this script!\" -F 'Yellow'",
         "Start-Process \"$dir\\portmaster-installer.exe\" -Verb RunAs -ArgumentList '/S' -Wait; Remove-Item \"$dir\\portmaster-installer.exe\"; Start-Sleep -Seconds 4",
-        "Copy-item \"$persist_dir\" \"$env:ProgramData\\Safing\\Portmaster\" -Recurse -Force -ErrorAction 'SilentlyContinue'",
+        "Copy-item \"$persist_dir\\*\" \"$env:ProgramData\\Safing\\Portmaster\\*\" -Recurse -Force -ErrorAction 'SilentlyContinue'",
         "if ($cmd -eq 'update') { Stop-Process -Name @('portmaster-start', 'portmaster-core_v*', 'portmaster-notifier_v*') -Force -ErrorAction 'SilentlyContinue'}"
     ],
     "post_install": "if ($cmd -eq 'install') { Write-Host 'Please restart your computer for Portmaster to install properly' -F 'Red' }",
     "pre_uninstall": [
         "if (!(is_admin)) { throw 'Administrator privileges are required' }",
         "Write-Host \"Please wait for Portmaster to $cmd. Do not cancel this script!\" -F 'Yellow'",
-        "Copy-item \"$env:ProgramData\\Safing\\Portmaster\" \"$persist_dir\" -Include @('config.json', 'databases', 'logs') -Recurse -Force -ErrorAction 'SilentlyContinue'; Start-Sleep -Seconds 4",
+        "Copy-item \"$env:ProgramData\\Safing\\Portmaster\\*\" \"$persist_dir\\*\" -Include @('config.json', 'databases', 'logs') -Recurse -Force -ErrorAction 'SilentlyContinue'; Start-Sleep -Seconds 4",
         "if ($cmd -eq 'uninstall') { Start-Process \"$env:ProgramData\\Safing\\Portmaster\\portmaster-uninstaller.exe\" -Verb RunAs -ArgumentList '/S' -Wait; Start-Sleep -Seconds 5 }"
     ],
     "post_uninstall": "if ($cmd -eq 'uninstall') { Write-Host 'Please restart your computer to uninstall Portmaster properly' -F 'Red' }",


### PR DESCRIPTION
The reason for this is because whenever the main portmaster repo publishes a release, the version number changes, but the hash does not. This is because that is the software being updated, not the package. The package version is 1.0.0, the software version is 1.0.7.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
