### PR TITLE
pdf24-creator-np: Fixed `autoupdate` hash extraction to be more accurate

### DIFF
--- a/bucket/pdf24-creator-np.json
+++ b/bucket/pdf24-creator-np.json
@@ -33,7 +33,7 @@
                 "url": "https://download.pdf24.org/pdf24-creator-$version.msi#/setup.msi_",
                 "hash": {
                     "url": "https://creator.pdf24.org/listVersions.php",
-                    "find": "<td>$sha256</td>"
+                    "regex": "$basename</a></td>\\s\\n\\s+<td>$sha256"
                 }
             }
         }

--- a/bucket/pdf24-creator-np.json
+++ b/bucket/pdf24-creator-np.json
@@ -33,7 +33,7 @@
                 "url": "https://download.pdf24.org/pdf24-creator-$version.msi#/setup.msi_",
                 "hash": {
                     "url": "https://creator.pdf24.org/listVersions.php",
-                    "regex": "$basename</a></td>\\s\\n\\s+<td>$sha256"
+                    "regex": "$basename</a></td>\\s\\n<td>$sha256"
                 }
             }
         }

--- a/bucket/pdf24-creator-np.json
+++ b/bucket/pdf24-creator-np.json
@@ -33,7 +33,7 @@
                 "url": "https://download.pdf24.org/pdf24-creator-$version.msi#/setup.msi_",
                 "hash": {
                     "url": "https://creator.pdf24.org/listVersions.php",
-                    "regex": "$basename</a></td>\\s\\n<td>$sha256"
+                    "regex": "$basename</a></td>\\n\\s<td>$sha256"
                 }
             }
         }

--- a/bucket/pdf24-creator-np.json
+++ b/bucket/pdf24-creator-np.json
@@ -8,8 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.pdf24.org/pdf24-creator-11.12.0.msi#/setup.msi_",
+            "url": "https://download.pdf24.org/pdf24-creator-11.12.0-x64.msi#/setup.msi_",
             "hash": "ff2fdcb6bdd02fef37f33acadaa935a4a37df4009f7db90716a98ec610c844d6"
+        },
+        "32bit": {
+            "url: "https://download.pdf24.org/pdf24-creator-11.12.0-x86.msi#/setup.msi_",
+            "hash": "bf370f13f5c02826ccab1099347106b890523603bb49c7764fdac804852bc0b1"
         }
     },
     "post_install": [
@@ -30,12 +34,15 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.pdf24.org/pdf24-creator-$version.msi#/setup.msi_",
-                "hash": {
-                    "url": "https://creator.pdf24.org/listVersions.php",
-                    "regex": "$basename</a></td>\\n<td>$sha256"
-                }
+                "url": "https://download.pdf24.org/pdf24-creator-$version-x64.msi#/setup.msi_"
+            },
+            "32bit": {
+                "url": "https://download.pdf24.org/pdf24-creator-$version-x86.msi#/setup.msi_"
             }
+        },
+        "hash": {
+            "url": "https://creator.pdf24.org/listVersions.php",
+            "regex": "$basename</a></td>\\n<td>$sha256"
         }
     }
 }

--- a/bucket/pdf24-creator-np.json
+++ b/bucket/pdf24-creator-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "11.11.0",
+    "version": "11.12.0",
     "homepage": "https://tools.pdf24.org/en/creator",
     "description": "Free and easy to use PDF software with several functions",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.pdf24.org/pdf24-creator-11.11.0.msi#/setup.msi_",
-            "hash": "959c18f32f5193cd73ae70a0605c8df8c0fab35bc68feb0f82d5f43052c20cf7"
+            "url": "https://download.pdf24.org/pdf24-creator-11.12.0.msi#/setup.msi_",
+            "hash": "ff2fdcb6bdd02fef37f33acadaa935a4a37df4009f7db90716a98ec610c844d6"
         }
     },
     "post_install": [

--- a/bucket/pdf24-creator-np.json
+++ b/bucket/pdf24-creator-np.json
@@ -33,7 +33,7 @@
                 "url": "https://download.pdf24.org/pdf24-creator-$version.msi#/setup.msi_",
                 "hash": {
                     "url": "https://creator.pdf24.org/listVersions.php",
-                    "regex": "$basename</a></td>\\n\\s<td>$sha256"
+                    "regex": "$basename</a></td>\\n<td>$sha256"
                 }
             }
         }

--- a/bucket/pdf24-creator-np.json
+++ b/bucket/pdf24-creator-np.json
@@ -12,7 +12,7 @@
             "hash": "ff2fdcb6bdd02fef37f33acadaa935a4a37df4009f7db90716a98ec610c844d6"
         },
         "32bit": {
-            "url: "https://download.pdf24.org/pdf24-creator-11.12.0-x86.msi#/setup.msi_",
+            "url": "https://download.pdf24.org/pdf24-creator-11.12.0-x86.msi#/setup.msi_",
             "hash": "bf370f13f5c02826ccab1099347106b890523603bb49c7764fdac804852bc0b1"
         }
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #163

**EDIT:** Added `32bit` to `architecture` and `autoupdate`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
