### PR TITLE
10x-np: Fix checkver

### DIFF
--- a/bucket/10x-np.json
+++ b/bucket/10x-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.30",
+    "version": "1.0.31.0",
     "homepage": "https://www.10xeditor.com/index.htm",
     "description": "A fast performing, feature packed C++ editor/IDE.",
     "license": {

--- a/bucket/10x-np.json
+++ b/bucket/10x-np.json
@@ -21,8 +21,15 @@
         "Start-Process \"$dir\\setup.exe\" -Wait -Verb 'RunAs' -WindowStyle 'Hidden' -Args @('/silent', '/uninstall'); Start-Sleep -Seconds 2"
     ],
     "checkver": {
-        "url": "https://www.10xeditor.com/versions.htm",
-        "regex": "Version\\s\\(([\\d.]+)\\)"
+        "script": [
+            "$dl_url = 'https://www.puredevsoftware.com/download.php?file=10xInstaller.exe#/setup.exe'",
+            "$dl = cache_path '10x-np' 'unknown' $dl_url",
+            "Invoke-WebRequest $dl_url -OutFile $dl",
+            "$ver = (Get-Item $dl).VersionInfo.ProductVersion",
+            "Move-Item -Force $dl (cache_path '10x-np' $ver $dl_url)",
+            "$ver"
+        ],
+        "regex": "([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/10x-np.json
+++ b/bucket/10x-np.json
@@ -4,7 +4,7 @@
     "description": "A fast performing, feature packed C++ editor/IDE.",
     "license": {
         "identifier": "Shareware",
-        "url": "https://www.10xeditor.com/License.htm"
+        "url": "https://www.puredevsoftware.com/download.php?file=10x_Editor_SaaS_License_Agreement.pdf"
     },
     "architecture": {
         "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Excavator has been updating to the wrong versions sporadically https://github.com/ScoopInstaller/Nonportable/commits/master/bucket/10x-np.json
Used the solution from the [spotify](https://github.com/ScoopInstaller/Extras/blob/630c27077813958c2257c8afc0454577b8fa4bf8/bucket/spotify.json#L34-L41) manifest to get the current version from the installer itself.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
