### PR TITLE
mayo-np: Add version 0.7.0

### DIFF
--- a/bucket/mayo-np.json
+++ b/bucket/mayo-np.json
@@ -1,0 +1,31 @@
+{
+    "bin": "mayo.exe",
+    "homepage": "https://github.com/fougue/mayo",
+    "description": "3D CAD viewer and converter based on Qt + OpenCascade",
+    "version": "0.7.0.1113",
+    "innosetup": true,
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fougue/mayo/releases/download/v0.7.0/mayo_v0.7.0.1113-f88a35d_winx64_installer.exe"
+        }
+    },
+    "hash": "",
+    "shortcuts": [
+        [
+            "mayo.exe",
+            "Mayo"
+        ]
+    ],
+    "license": "BSD 2-Clause",
+    "checkver": {
+        "url": "https://api.github.com/repos/fougue/mayo/releases",
+        "regex": "mayo_v([\\d.]+)-(?<hash>[a-f0-9]+)_winx64_installer.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fougue/mayo/releases/download/v$matchHead/mayo_v$version-$matchHash_winx64_installer.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Relates to https://github.com/fougue/mayo/issues/156

Because [Mayo](https://github.com/fougue/mayo) has the hash of the last commit in its release binary name, the autoupdate / checkver is a bit more complicated.
Is the way I solved this the correct way, or is there a simpler/better way of setting up the autoupdate?

There also is no hash provided for the binary. Is this a problem? `hash` is not required but there are warnings that there is no hash. What should I do about this, or is it ok as it is?

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
