### PR TITLE
fix: update auto-dark-mode-np executable hash

### DIFF
--- a/bucket/auto-dark-mode-np.json
+++ b/bucket/auto-dark-mode-np.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/Armin2208/Windows-Auto-Night-Mode",
     "license": "GPL-3.0-only",
     "url": "https://github.com/AutoDarkMode/Windows-Auto-Night-Mode/releases/download/10.4.0.35/AutoDarkModeX_10.4.0.35.exe#/setup.exe",
-    "hash": "2e9cceef1eeb459556645035095f15d2d26ef8be35362dbae2b0c709d7bb9c6a",
+    "hash": "9f4933145df2341ac271ae1e91296fde306ecd675e1eb307eb2d4f9bedbcce84",
     "notes": "Settings need to be reapplied after updating.",
     "installer": {
         "script": [


### PR DESCRIPTION
Hi, I am an Auto Dark Mode maintainer.

We had to update the executable file, because there was an issue with azure code signing not having applied properly.
The file is now digitally signed with MS Azure.

The automatic update github action probably won't pick up this action, because we replaced the executable in the release in-place instead of publishing a new build.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
