### PR TITLE
powertoys@0.82.1: Fix for the tag change

### DIFF
--- a/bucket/powertoys-np.json
+++ b/bucket/powertoys-np.json
@@ -8,7 +8,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/V0.82.1/PowerToysSetup-0.82.1-x64.exe#/setup.exe",
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.82.1/PowerToysSetup-0.82.1-x64.exe#/setup.exe",
             "hash": "b8fa7e7c8f88b69e070e234f561d32807634e2e9d782edbb9dc35f3a454f2264"
         }
     },
@@ -26,13 +26,17 @@
             "/uninstall"
         ]
     },
-    "checkver": "github",
+    "checkver": {
+        "url": "https://api.github.com/repos/microsoft/PowerToys/releases",
+        "jsonpath": "$[0].assets[*].browser_download_url",
+        "regex": "/releases/download/(?<tag>[\\w.]+)/PowerToysSetup-([\\d.]+)-x64\\.exe"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/microsoft/PowerToys/releases/download/V$version/PowerToysSetup-$version-x64.exe#/setup.exe",
+                "url": "https://github.com/microsoft/PowerToys/releases/download/$matchTag/PowerToysSetup-$version-x64.exe#/setup.exe",
                 "hash": {
-                    "url": "https://github.com/microsoft/PowerToys/releases/tag/V$version",
+                    "url": "https://github.com/microsoft/PowerToys/releases/tag/$matchTag",
                     "regex": ">$sha256<"
                 }
             }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
As suggested in #321, revert back to lowercase and change tag extraction similar than the one for portable version.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #321 due to [powertoys@0.82.1: Fix for the tag change #13622](https://github.com/ScoopInstaller/Extras/pull/13622) with same tag extraction method than [powertoys: Update to version 0.82.1 #13612](https://github.com/ScoopInstaller/Extras/pull/13612)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
