### PR TITLE
Update version of all 3 VoiceMeeter application packages

### DIFF
--- a/bucket/voicemeeter-banana-np.json
+++ b/bucket/voicemeeter-banana-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.6.8",
+    "version": "3.1.1.3",
     "description": "Audio mixer application endowed with virtual audio device (BANANA/advanced version)",
     "homepage": "https://vb-audio.com/Voicemeeter/",
     "license": {

--- a/bucket/voicemeeter-banana-np.json
+++ b/bucket/voicemeeter-banana-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.1.1.3",
+    "version": "2.1.1.3",
     "description": "Audio mixer application endowed with virtual audio device (BANANA/advanced version)",
     "homepage": "https://vb-audio.com/Voicemeeter/",
     "license": {
@@ -23,7 +23,7 @@
     },
     "checkver": {
         "url": "https://vb-audio.com/Voicemeeter/banana.htm",
-        "regex": "Voicemeeter ([\\d.]+) \\(EXE file\\)"
+        "regex": "Voicemeeter ([\\d.]+) \\(ZIP Package\\)"
     },
     "autoupdate": {
         "url": "https://download.vb-audio.com/Download_CABLE/VoicemeeterProSetup.exe#/setup.exe"

--- a/bucket/voicemeeter-np.json
+++ b/bucket/voicemeeter-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.8.8",
+    "version": "1.1.1.3",
     "description": "Audio mixer application endowed with virtual audio device (standard version)",
     "homepage": "https://vb-audio.com/Voicemeeter/",
     "license": {

--- a/bucket/voicemeeter-np.json
+++ b/bucket/voicemeeter-np.json
@@ -23,7 +23,7 @@
     },
     "checkver": {
         "url": "https://vb-audio.com/Voicemeeter/index.htm",
-        "regex": "Voicemeeter ([\\d.]+) \\(EXE file\\)"
+        "regex": "Voicemeeter ([\\d.]+) \\(ZIP Package\\)"
     },
     "autoupdate": {
         "url": "https://download.vb-audio.com/Download_CABLE/VoicemeeterSetup.exe#/setup.exe"

--- a/bucket/voicemeeter-potato-np.json
+++ b/bucket/voicemeeter-potato-np.json
@@ -23,7 +23,7 @@
     },
     "checkver": {
         "url": "https://vb-audio.com/Voicemeeter/potato.htm",
-        "regex": "Voicemeeter ([\\d.]+) \\(EXE file\\)"
+        "regex": "Voicemeeter ([\\d.]+) \\(ZIP Package\\)"
     },
     "autoupdate": {
         "url": "https://download.vb-audio.com/Download_CABLE/Voicemeeter8Setup.exe#/setup.exe"

--- a/bucket/voicemeeter-potato-np.json
+++ b/bucket/voicemeeter-potato-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.0.2.8",
+    "version": "3.1.1.3",
     "description": "Audio mixer application endowed with virtual audio device (POTATO/ultimate version)",
     "homepage": "https://vb-audio.com/Voicemeeter/",
     "license": {


### PR DESCRIPTION
Updates the following packages to the correct version when downloading from the source:

- `voicemeeter-np`
- `voicemeeter-banana-np`
- `voicemeeter-potato-np`

Relates to #328 
Relates to #329 
Relates to #330

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
