### PR TITLE
mullvadvpn-np@2024.4: update to version 2024.4

### DIFF
--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -1,12 +1,12 @@
 {
-    "version": "2023.6",
+    "version": "2024.4",
     "homepage": "https://mullvad.net/en/",
     "description": "The official desktop client for Mullvad VPN, a privacy-respecting VPN service.",
     "license": "GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://mullvad.net/media/app/MullvadVPN-2023.6.exe#/setup.exe",
-            "hash": "1a212857d3edcfe44cfdf0ac50db27a1fb325721f7fd9aa9a1e8fcc8b4bda64c"
+            "url": "https://mullvad.net/media/app/MullvadVPN-2024.4.exe#/setup.exe",
+            "hash": "40b6c1d8cb9259d944c737d9e3cdb483bf425335069fd2685cf13629334cc938"
         }
     },
     "pre_install": [

--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -1,11 +1,11 @@
 {
     "version": "2024.4",
-    "homepage": "https://mullvad.net/en/vpn",
     "description": "The official desktop client for Mullvad VPN, a privacy-respecting VPN service.",
+    "homepage": "https://mullvad.net/en/vpn",
     "license": "GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://mullvad.net/media/app/MullvadVPN-2024.4.exe#/setup.exe",
+            "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/2024.4/MullvadVPN-2024.4.exe#/setup.exe",
             "hash": "40b6c1d8cb9259d944c737d9e3cdb483bf425335069fd2685cf13629334cc938"
         }
     },
@@ -32,7 +32,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://mullvad.net/media/app/MullvadVPN-$version.exe#/setup.exe"
+                "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/$version/MullvadVPN-$version.exe#/setup.exe"
             }
         }
     }

--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -9,18 +9,22 @@
             "hash": "40b6c1d8cb9259d944c737d9e3cdb483bf425335069fd2685cf13629334cc938"
         }
     },
-    "pre_install": [
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "Start-Process \"$dir\\setup.exe\" -Verb 'RunAs' -Args @('/allusers', '/S')",
-        "while (!(Get-Process -Name 'mullvad-daemon' -ErrorAction 'SilentlyContinue')) { Start-Sleep -Seconds 5 }",
-        "Remove-Item \"$dir\\setup.exe\""
-    ],
-    "pre_uninstall": [
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "Stop-Service -Name 'MullvadVPN' -ErrorAction 'SilentlyContinue' -Force; Stop-Process -Name 'Mullvad VPN' -ErrorAction 'SilentlyContinue' -Force",
-        "Start-Process \"$env:ProgramFiles\\Mullvad VPN\\Uninstall Mullvad VPN.exe\" -Wait -Verb 'RunAs' -Args @('/allusers', '/S')",
-        "Start-Sleep -Seconds 2"
-    ],
+    "installer": {
+        "script": [
+            "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+            "Start-Process \"$dir\\setup.exe\" -Verb 'RunAs' -Args @('/allusers', '/S')",
+            "while (!(Get-Process -Name 'mullvad-daemon' -ErrorAction 'SilentlyContinue')) { Start-Sleep -Seconds 5 }",
+            "Remove-Item \"$dir\\setup.exe\""
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+            "Stop-Service -Name 'MullvadVPN' -ErrorAction 'SilentlyContinue' -Force; Stop-Process -Name 'Mullvad VPN' -ErrorAction 'SilentlyContinue' -Force",
+            "Start-Process \"$env:ProgramFiles\\Mullvad VPN\\Uninstall Mullvad VPN.exe\" -Wait -Verb 'RunAs' -Args @('/allusers', '/S')",
+            "Start-Sleep -Seconds 2"
+        ]
+    },
     "checkver": {
         "url": "https://mullvad.net/en/download/windows/",
         "regex": ">Latest\\sversion:\\s([\\d.]+)"

--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -1,6 +1,6 @@
 {
     "version": "2024.4",
-    "homepage": "https://mullvad.net/en/",
+    "homepage": "https://mullvad.net/en/vpn",
     "description": "The official desktop client for Mullvad VPN, a privacy-respecting VPN service.",
     "license": "GPL-3.0",
     "architecture": {

--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -26,8 +26,7 @@
         ]
     },
     "checkver": {
-        "url": "https://mullvad.net/en/download/windows/",
-        "regex": ">Latest\\sversion:\\s([\\d.]+)"
+        "github": "https://github.com/mullvad/mullvadvpn-app"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #327 #306 #305 #290 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

## Reason for Change
Mullvad has changed some of URLs, since they've added Mullvad Browser. So the checkver would fail due to hitting a redirect URL (e.g., [see check for #327](https://github.com/ScoopInstaller/Nonportable/pull/327/checks#step:3:469)). But, I've figured rather than changing it to the new URL I could change the manifest to use the GitHub checkver, which should hopefully avoid any future breaking changes.

## Summary of Changes
* Updated the version number and hash to the latest: 2024.4
* Updated the homepage URL to the homepage of the VPN product
* Moved install/uninstall scripts to `install.script` and `uninstall.script`, respectively - this seemed like a more appropriate place for these scripts.
* Updated the download URL and checkver to use GitHub
