### PR TITLE
mullvadvpn-np@2024.5: update to version 2024.5

### DIFF
--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -1,12 +1,12 @@
 {
-    "version": "2023.6",
+    "version": "2024.4",
     "homepage": "https://mullvad.net/en/",
     "description": "The official desktop client for Mullvad VPN, a privacy-respecting VPN service.",
     "license": "GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://mullvad.net/media/app/MullvadVPN-2023.6.exe#/setup.exe",
-            "hash": "1a212857d3edcfe44cfdf0ac50db27a1fb325721f7fd9aa9a1e8fcc8b4bda64c"
+            "url": "https://mullvad.net/media/app/MullvadVPN-2024.4.exe#/setup.exe",
+            "hash": "40b6c1d8cb9259d944c737d9e3cdb483bf425335069fd2685cf13629334cc938"
         }
     },
     "pre_install": [

--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -1,11 +1,11 @@
 {
     "version": "2024.4",
-    "homepage": "https://mullvad.net/en/vpn",
     "description": "The official desktop client for Mullvad VPN, a privacy-respecting VPN service.",
+    "homepage": "https://mullvad.net/en/vpn",
     "license": "GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://mullvad.net/media/app/MullvadVPN-2024.4.exe#/setup.exe",
+            "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/2024.4/MullvadVPN-2024.4.exe#/setup.exe",
             "hash": "40b6c1d8cb9259d944c737d9e3cdb483bf425335069fd2685cf13629334cc938"
         }
     },
@@ -32,7 +32,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://mullvad.net/media/app/MullvadVPN-$version.exe#/setup.exe"
+                "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/$version/MullvadVPN-$version.exe#/setup.exe"
             }
         }
     }

--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -9,18 +9,22 @@
             "hash": "40b6c1d8cb9259d944c737d9e3cdb483bf425335069fd2685cf13629334cc938"
         }
     },
-    "pre_install": [
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "Start-Process \"$dir\\setup.exe\" -Verb 'RunAs' -Args @('/allusers', '/S')",
-        "while (!(Get-Process -Name 'mullvad-daemon' -ErrorAction 'SilentlyContinue')) { Start-Sleep -Seconds 5 }",
-        "Remove-Item \"$dir\\setup.exe\""
-    ],
-    "pre_uninstall": [
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "Stop-Service -Name 'MullvadVPN' -ErrorAction 'SilentlyContinue' -Force; Stop-Process -Name 'Mullvad VPN' -ErrorAction 'SilentlyContinue' -Force",
-        "Start-Process \"$env:ProgramFiles\\Mullvad VPN\\Uninstall Mullvad VPN.exe\" -Wait -Verb 'RunAs' -Args @('/allusers', '/S')",
-        "Start-Sleep -Seconds 2"
-    ],
+    "installer": {
+        "script": [
+            "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+            "Start-Process \"$dir\\setup.exe\" -Verb 'RunAs' -Args @('/allusers', '/S')",
+            "while (!(Get-Process -Name 'mullvad-daemon' -ErrorAction 'SilentlyContinue')) { Start-Sleep -Seconds 5 }",
+            "Remove-Item \"$dir\\setup.exe\""
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+            "Stop-Service -Name 'MullvadVPN' -ErrorAction 'SilentlyContinue' -Force; Stop-Process -Name 'Mullvad VPN' -ErrorAction 'SilentlyContinue' -Force",
+            "Start-Process \"$env:ProgramFiles\\Mullvad VPN\\Uninstall Mullvad VPN.exe\" -Wait -Verb 'RunAs' -Args @('/allusers', '/S')",
+            "Start-Sleep -Seconds 2"
+        ]
+    },
     "checkver": {
         "url": "https://mullvad.net/en/download/windows/",
         "regex": ">Latest\\sversion:\\s([\\d.]+)"

--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -1,6 +1,6 @@
 {
     "version": "2024.4",
-    "homepage": "https://mullvad.net/en/",
+    "homepage": "https://mullvad.net/en/vpn",
     "description": "The official desktop client for Mullvad VPN, a privacy-respecting VPN service.",
     "license": "GPL-3.0",
     "architecture": {

--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -26,8 +26,7 @@
         ]
     },
     "checkver": {
-        "url": "https://mullvad.net/en/download/windows/",
-        "regex": ">Latest\\sversion:\\s([\\d.]+)"
+        "github": "https://github.com/mullvad/mullvadvpn-app"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -1,12 +1,12 @@
 {
-    "version": "2024.4",
+    "version": "2024.5",
     "description": "The official desktop client for Mullvad VPN, a privacy-respecting VPN service.",
     "homepage": "https://mullvad.net/en/vpn",
     "license": "GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/2024.4/MullvadVPN-2024.4.exe#/setup.exe",
-            "hash": "40b6c1d8cb9259d944c737d9e3cdb483bf425335069fd2685cf13629334cc938"
+            "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/2024.5/MullvadVPN-2024.5.exe#/setup.exe",
+            "hash": "5411fef047adadb03e49ab2b9f5b5efd0b1ab4f8c544dd4842582444895462c8"
         }
     },
     "installer": {

--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -26,7 +26,8 @@
         ]
     },
     "checkver": {
-        "github": "https://github.com/mullvad/mullvadvpn-app"
+        "url": "https://api.mullvad.net/app/v1/releases/windows/$version",
+        "jsonpath": "$.latest_stable"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #327 #306 #305 #290 #336 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

## Reason for Change
Mullvad has changed some of URLs, since they've added Mullvad Browser. So the checkver would fail due to hitting a redirect URL (e.g., [see check for #327](https://github.com/ScoopInstaller/Nonportable/pull/327/checks#step:3:469)). ~~But, I've figured rather than changing it to the new URL I could change the manifest to use the GitHub checkver, which should hopefully avoid any future breaking changes.~~ The GitHub repo for the Mullvad VPN app is for all platforms and the different platforms can have separate releases, updating what "latest" points to (e.g. `android/2024.4`), leading checkver to fail. So, I've changed checkver to use the Mullvad API to query directly for the latest version for *Windows*.

## Summary of Changes
* Updated the version number and hash to the latest: 2024.5
* Updated the homepage URL to the homepage of the _VPN_ product
* Moved install/uninstall scripts to `install.script` and `uninstall.script`, respectively - this seemed like a more appropriate place for these scripts.
* Updated the download URL to use GitHub
* **Updated `checkver` to use the Mullvad API to query for the version and extract it using `jsonpath`**