### PR TITLE
pgadmin4-np: Silent user install support

### DIFF
--- a/bucket/pgadmin4-np.json
+++ b/bucket/pgadmin4-np.json
@@ -11,19 +11,23 @@
     },
     "installer": {
         "args": [
-            "/verysilent",
-            "/nocancel",
-            "/norestart",
-            "/dir=$dir"
+            "/VERYSILENT",
+            "/SUPPRESSMSGBOXES",
+            "/SP-",
+            "/NOCANCEL",
+            "/NORESTART",
+            "/NOICONS",
+            "/DIR=$dir"
         ]
     },
-    "post_install": "Remove-Item -Recurse \"$([Environment]::GetFolderPath('commonstartmenu'))\\Programs\\pgAdmin 4\"",
     "uninstaller": {
         "file": "unins000.exe",
         "args": [
-            "/verysilent",
-            "/nocancel",
-            "/norestart"
+            "/VERYSILENT",
+            "/SUPPRESSMSGBOXES",
+            "/SP-",
+            "/NOCANCEL",
+            "/NORESTART"
         ]
     },
     "bin": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Refresh of installer arguments in order to:

* support silent installs in both user and global contexts => `SUPPRESSMSGBOXES` will let the installer assume local user install if it does not have admin rights instead of asking for elevated privileges

* get rid of a post_install error in case of local user install  (because 'pgAdmin 4' folder can't be located under the common start menu) by using `NOICONS` during install instead of  trying to remove start menu icons after the fact


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
