### PR TITLE
virtualbox-with-extension-pack-np@7.0.20:  fix autoupdate url

### DIFF
--- a/bucket/virtualbox-with-extension-pack-np.json
+++ b/bucket/virtualbox-with-extension-pack-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.1.2",
+    "version": "7.1.4",
     "description": "Powerful x86 and AMD64/Intel64 virtualization product for enterprise as well as home use.",
     "homepage": "https://www.virtualbox.org/",
     "license": {
@@ -14,12 +14,12 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://download.virtualbox.org/virtualbox/7.1.2/VirtualBox-7.1.2-164945-Win.exe#/setup.exe",
-                "https://download.virtualbox.org/virtualbox/7.1.2/Oracle_VirtualBox_Extension_Pack-7.1.2.vbox-extpack"
+                "https://download.virtualbox.org/virtualbox/7.1.4/VirtualBox-7.1.4-165100-Win.exe#/setup.exe",
+                "https://download.virtualbox.org/virtualbox/7.1.4/Oracle_VirtualBox_Extension_Pack-7.1.4.vbox-extpack"
             ],
             "hash": [
-                "95be216f865155f64cf461b712462405e25c600bd92b873d89ac43e8b564c15c",
-                "afd7a79ce2bd0142a890ac01f580534f1a96f1ffbaa1ad17d7512751cde19f08"
+                "f970e275f59eeeb129aab88a78dae80784370742b5051650a7926c9ea64afeac",
+                "9dd60ef3c52c2a318fbbb6faace5862a299b61f678a579988869865dcf7390b6"
             ]
         }
     },

--- a/bucket/virtualbox-with-extension-pack-np.json
+++ b/bucket/virtualbox-with-extension-pack-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.0.20",
+    "version": "7.1.2",
     "description": "Powerful x86 and AMD64/Intel64 virtualization product for enterprise as well as home use.",
     "homepage": "https://www.virtualbox.org/",
     "license": {
@@ -14,12 +14,12 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://download.virtualbox.org/virtualbox/7.0.20/VirtualBox-7.0.20-163906-Win.exe#/setup.exe",
-                "https://download.virtualbox.org/virtualbox/7.0.20/Oracle_VM_VirtualBox_Extension_Pack-7.0.20.vbox-extpack"
+                "https://download.virtualbox.org/virtualbox/7.1.2/VirtualBox-7.1.2-164945-Win.exe#/setup.exe",
+                "https://download.virtualbox.org/virtualbox/7.1.2/Oracle_VirtualBox_Extension_Pack-7.1.2.vbox-extpack"
             ],
             "hash": [
-                "fa3544162eee87b660999bd913f76ccb2e5a706928ef2c2e29811e4ac76fb166",
-                "d750fb17688d70e0cb2d7b06f1ad3a661303793f4d1ac39cfa9a54806b89da25"
+                "95be216f865155f64cf461b712462405e25c600bd92b873d89ac43e8b564c15c",
+                "afd7a79ce2bd0142a890ac01f580534f1a96f1ffbaa1ad17d7512751cde19f08"
             ]
         }
     },
@@ -76,7 +76,7 @@
             "64bit": {
                 "url": [
                     "https://download.virtualbox.org/virtualbox/$matchHead/VirtualBox-$version-$matchRevision-Win.exe#/setup.exe",
-                    "https://download.virtualbox.org/virtualbox/$matchHead/Oracle_VM_VirtualBox_Extension_Pack-$matchHead.vbox-extpack"
+                    "https://download.virtualbox.org/virtualbox/$matchHead/Oracle_VirtualBox_Extension_Pack-$matchHead.vbox-extpack"
                 ]
             }
         },


### PR DESCRIPTION
Oracle changed the download path for the Extension Pack.  Updated autoupdate URL, then updated manifest using `checkver.ps1`.

Closes #356 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
