### PR TITLE
UniGetUI: Add version 3.1.2

### DIFF
--- a/bucket/unigetui-np.json
+++ b/bucket/unigetui-np.json
@@ -1,0 +1,37 @@
+{
+    "version": "3.1.2",
+    "description": "UniGetUI - An intuitive GUI for the most common CLI package managers for Windows 10 and 11",
+    "homepage": "https://www.marticliment.com/unigetui",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/marticliment/UniGetUI/blob/main/LICENSE"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/marticliment/UniGetUI/releases/download/3.1.2/UniGetUI.Installer.exe#/setup.exe",
+            "hash": "456A4F2D548C590ECF56E90D1846DDF2BCD9E3D7BDE6747602328885675A2C8F"
+        }
+    },
+    "installer": {
+        "script": [
+            "if (!(is_admin)) { Write-Host \"\nERROR: $app requires admin rights to $cmd\" -ForegroundColor DarkRed; break }",
+            "Start-Process -Wait \"$dir\\setup.exe\" \"/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /NoAutoStart /ALLUSERS /NoWinGet /NoChocolatey\""
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(is_admin)) { Write-Host \"\nERROR: $app requires admin rights to $cmd\" -ForegroundColor DarkRed; break }",
+            "$uninstaller = (Get-ItemProperty -ErrorAction Ignore \"HKCU:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{889610CC-4337-4BDB-AC3B-4F21806C0BDE}_is1\" -Name UninstallString).UninstallString",
+            "if (!$uninstaller) { $uninstaller = (Get-ItemProperty -ErrorAction Ignore \"HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{889610CC-4337-4BDB-AC3B-4F21806C0BDE}_is1\" -Name UninstallString).UninstallString }",
+            "if (!$uninstaller) { warn 'Could not find app info in registry' }",
+            "Start-Process -Wait \"$uninstaller\" \"/VERYSILENT\" -Verb RunAs"
+        ]
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/marticliment/UniGetUI/releases/download/$version/UniGetUI.Installer.exe#/setup.exe#/setup.exe"
+            }
+        }
+    }
+}

--- a/bucket/unigetui-np.json
+++ b/bucket/unigetui-np.json
@@ -8,19 +8,19 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/marticliment/UniGetUI/releases/download/3.1.2/UniGetUI.Installer.exe#/setup.exe",
-            "hash": "456A4F2D548C590ECF56E90D1846DDF2BCD9E3D7BDE6747602328885675A2C8F"
+            "url": "https://github.com/marticliment/UniGetUI/releases/download/3.1.2/UniGetUI.Installer.exe#/setup.exe#/setup.exe",
+            "hash": "456a4f2d548c590ecf56e90d1846ddf2bcd9e3d7bde6747602328885675a2c8f"
         }
     },
     "installer": {
         "script": [
-            "if (!(is_admin)) { Write-Host \"\nERROR: $app requires admin rights to $cmd\" -ForegroundColor DarkRed; break }",
+            "if (!(is_admin)) { Write-Host \" ERROR: $app requires admin rights to $cmd\" -ForegroundColor DarkRed; break }",
             "Start-Process -Wait \"$dir\\setup.exe\" \"/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /NoAutoStart /ALLUSERS /NoWinGet /NoChocolatey\""
         ]
     },
     "uninstaller": {
         "script": [
-            "if (!(is_admin)) { Write-Host \"\nERROR: $app requires admin rights to $cmd\" -ForegroundColor DarkRed; break }",
+            "if (!(is_admin)) { Write-Host \" ERROR: $app requires admin rights to $cmd\" -ForegroundColor DarkRed; break }",
             "$uninstaller = (Get-ItemProperty -ErrorAction Ignore \"HKCU:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{889610CC-4337-4BDB-AC3B-4F21806C0BDE}_is1\" -Name UninstallString).UninstallString",
             "if (!$uninstaller) { $uninstaller = (Get-ItemProperty -ErrorAction Ignore \"HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{889610CC-4337-4BDB-AC3B-4F21806C0BDE}_is1\" -Name UninstallString).UninstallString }",
             "if (!$uninstaller) { warn 'Could not find app info in registry' }",
@@ -33,5 +33,8 @@
                 "url": "https://github.com/marticliment/UniGetUI/releases/download/$version/UniGetUI.Installer.exe#/setup.exe#/setup.exe"
             }
         }
+    },
+    "checkver": {
+        "github": "https://github.com/marticliment/UniGetUI"
     }
 }


### PR DESCRIPTION
Add UniGetUI to the nonportable bucket (this package replaces the deprecated broken extras/wingetui, see https://github.com/ScoopInstaller/Extras/pull/14286 for more details)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
