### PR TITLE
office-365-apps-np@*: fix version checker

### DIFF
--- a/bucket/office-365-apps-minimal-np.json
+++ b/bucket/office-365-apps-minimal-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "22.14.0",
+    "version": "1.5.5.0",
     "description": "Family of client software, server software and services developed by Microsoft. This package only includes Excel, PowerPoint and Word.",
     "homepage": "https://www.office.com/",
     "license": {
@@ -8,7 +8,7 @@
     },
     "depends": "7zip19.00-helper",
     "url": "https://download.microsoft.com/download/#/dl.7z_",
-    "hash": "d8458a8a9c13320747738c177980216937180a29e119ccc8817381c0bf5504fd",
+    "hash": "7611a290f5a0d11b743eef295ba1f49905f7732a97fda53027b4275c49aeaa18",
     "pre_install": [
         "$scriptdir = \"$bucketsdir\\nonportable\\scripts\"",
         "if ($architecture -eq '64bit') {",

--- a/bucket/office-365-apps-minimal-np.json
+++ b/bucket/office-365-apps-minimal-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.5.5.0",
+    "version": "16.0.18526.20146",
     "description": "Family of client software, server software and services developed by Microsoft. This package only includes Excel, PowerPoint and Word.",
     "homepage": "https://www.office.com/",
     "license": {
@@ -7,8 +7,8 @@
         "url": "https://www.microsoft.com/licensing/terms/productoffering/OfficeDesktopApplicationsWindows/MCA"
     },
     "depends": "7zip19.00-helper",
-    "url": "https://download.microsoft.com/download/#/dl.7z_",
-    "hash": "7611a290f5a0d11b743eef295ba1f49905f7732a97fda53027b4275c49aeaa18",
+    "url": "https://download.microsoft.com/download/6c1eeb25-cf8b-41d9-8d0d-cc1dbc032140/officedeploymenttool_18526-20146.exe#/dl.7z_",
+    "hash": "3d1936ecf7d89847f3c94132f828bfe0beca401a5b0877ab2e0253a8571e6508",
     "pre_install": [
         "$scriptdir = \"$bucketsdir\\nonportable\\scripts\"",
         "if ($architecture -eq '64bit') {",
@@ -33,7 +33,7 @@
             "$ProgressPreference = 'SilentlyContinue'",
             "$url1 = 'https://docs.microsoft.com/en-us/officeupdates/odt-release-history'",
             "$regex1 = '<p>Version ([\\d.]+)'",
-            "$url2 = 'https://www.microsoft.com/en-au/download/confirmation.aspx?id=49117'",
+            "$url2 = 'https://www.microsoft.com/en-us/download/details.aspx?id=49117'",
             "$regex2 = 'download/([\\w/-]+)(officedeploymenttool_[\\d-]+\\.exe)'",
             "",
             "$cont = $(Invoke-WebRequest $url1).Content",

--- a/bucket/office-365-apps-np.json
+++ b/bucket/office-365-apps-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.2.0",
+    "version": "16.0.18526.20146",
     "description": "Family of client software, server software and services developed by Microsoft.",
     "homepage": "https://www.office.com/",
     "license": {
@@ -7,8 +7,8 @@
         "url": "https://www.microsoft.com/licensing/terms/productoffering/OfficeDesktopApplicationsWindows/MCA"
     },
     "depends": "7zip19.00-helper",
-    "url": "https://download.microsoft.com/download/#/dl.7z_",
-    "hash": "bbdf62a4ca86c89ffdb53fdfcdd5161c6e0cc8bf5e88da200ad99636b8de52fd",
+    "url": "https://download.microsoft.com/download/6c1eeb25-cf8b-41d9-8d0d-cc1dbc032140/officedeploymenttool_18526-20146.exe#/dl.7z_",
+    "hash": "3d1936ecf7d89847f3c94132f828bfe0beca401a5b0877ab2e0253a8571e6508",
     "pre_install": [
         "$scriptdir = \"$bucketsdir\\nonportable\\scripts\"",
         "if ($architecture -eq '64bit') {",
@@ -33,7 +33,7 @@
             "$ProgressPreference = 'SilentlyContinue'",
             "$url1 = 'https://docs.microsoft.com/en-us/officeupdates/odt-release-history'",
             "$regex1 = '<p>Version ([\\d.]+)'",
-            "$url2 = 'https://www.microsoft.com/en-au/download/confirmation.aspx?id=49117'",
+            "$url2 = 'https://www.microsoft.com/en-us/download/details.aspx?id=49117'",
             "$regex2 = 'download/([\\w/-]+)(officedeploymenttool_[\\d-]+\\.exe)'",
             "",
             "$cont = $(Invoke-WebRequest $url1).Content",


### PR DESCRIPTION
This PR fixes the download url , so it doesn't reports random values.
This in turn will fix the hash issues with the following packages:
* `office-365-apps-np`
* `office-365-apps-minimal-np`

This will also fix the rouge version check running every excavation event, resulting in at least 600 incorrect commits.
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!-- or -->
Relates to #419 #417 #412 #411 #407  #402 #396 #388 #386 #384 #383 #382 ... etc.
Closes: #423 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
