### PR TITLE
notepads-np: Fix $package_name value error in post_install script

### DIFF
--- a/bucket/notepads-np.json
+++ b/bucket/notepads-np.json
@@ -16,7 +16,10 @@
         ]
     },
     "post_install": [
-        "$package_name = (Get-AppxPackage -Name '*JackieLiu*Notepads*').PackageFamilyName",
+        "while ($null -eq $package_name) {",
+        "    Start-Sleep -Milliseconds 250",
+        "    $package_name = (Get-AppxPackage -Name '*JackieLiu*Notepads*').PackageFamilyName",
+        "}",
         "while (-not (Test-Path \"$env:LOCALAPPDATA\\Packages\\$package_name\\Settings\\settings.dat\")) { Start-Sleep -Milliseconds 250 }",
         "Copy-Item -Recurse -Force \"$dir\\Settings\" -Destination \"$env:LOCALAPPDATA\\Packages\\$package_name\""
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Get appx package name for `$package_name` one more time if it is null

Tested with debug function

```json
{
    "post_install": [
        "while ($null -eq $package_name) {",
        "    Start-Sleep -Milliseconds 250",
        "    $package_name = (Get-AppxPackage -Name '*JackieLiu*Notepads*').PackageFamilyName",
        "}",
        "debug $package_name",
        "while (-not (Test-Path \"$env:LOCALAPPDATA\\Packages\\$package_name\\Settings\\settings.dat\")) { Start-Sleep -Milliseconds 250 }",
        "Copy-Item -Recurse -Force \"$dir\\Settings\" -Destination \"$env:LOCALAPPDATA\\Packages\\$package_name\""
    ]
}
```
Output in installation

```plaintext
> gsudo scoop install notepads-np
WARN  Scoop uses 'aria2c' for multi-connection downloads.
WARN  Should it cause issues, run 'scoop config aria2-enabled false' to disable it.
WARN  To disable this warning, run 'scoop config aria2-warning-enabled false'.
Installing 'notepads-np' (1.5.6.0) [64bit] from 'nonportable' bucket
Loading Notepads_1.5.6.0_x86_x64_arm64.msixbundle from cache.
Checking hash of Notepads_1.5.6.0_x86_x64_arm64.msixbundle ... ok.
Running installer script...done.
Linking ~\scoop\apps\notepads-np\current => ~\scoop\apps\notepads-np\1.5.6.0
Persisting Settings
Running post_install script...DEBUG[1743514968.30779] $package_name = 19282JackieLiu.Notepads-Beta_echhpq9pdbte8 -> :5:1
done.
'notepads-np' (1.5.6.0) was installed successfully!
```

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #430 
<!-- or -->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
