### PR TITLE
file-converter-np: Update to v2.1, 64bit only and fix wrong homepage URL

### DIFF
--- a/bucket/file-converter-np.json
+++ b/bucket/file-converter-np.json
@@ -1,16 +1,12 @@
 {
-    "version": "1.2.3",
+    "version": "2.1",
     "homepage": "https://file-converter.io",
     "description": "A Windows File Explorer shell extension that allows for converting and compressing one or several file(s) using the context menu.",
     "license": "GPL-3.0",
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/Tichau/FileConverter/releases/download/v1.2.3/FileConverter-1.2.3-x86-setup.msi#/setup.msi_",
-            "hash": "00BC76929BC173491F2107B97836C7CB18E0BD52917442CDC743A9C4FD00BF3F"
-        },
         "64bit": {
-            "url": "https://github.com/Tichau/FileConverter/releases/download/v1.2.3/FileConverter-1.2.3-x64-setup.msi#/setup.msi_",
-            "hash": "2410944075ED4F0BFD4740E9EE2FD17EAE4922980937D738C42BED07AC130C32"
+            "url": "https://github.com/Tichau/FileConverter/releases/download/v2.1/FileConverter-2.1-x64-setup.msi#/setup.msi_",
+            "hash": "9570174bf58e9044265578b8a63ed007caec1003c4ad89f8d52f815c00a6a0b7"
         }
     },
     "pre_install": [
@@ -29,9 +25,6 @@
     },
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/Tichau/FileConverter/releases/download/v$version/FileConverter-$version-x86-setup.msi#/setup.msi_"
-            },
             "64bit": {
                 "url": "https://github.com/Tichau/FileConverter/releases/download/v$version/FileConverter-$version-x64-setup.msi#/setup.msi_"
             }

--- a/bucket/file-converter-np.json
+++ b/bucket/file-converter-np.json
@@ -1,6 +1,6 @@
 {
     "version": "1.2.3",
-    "homepage": "https://file-converter.org/",
+    "homepage": "https://file-converter.io",
     "description": "A Windows File Explorer shell extension that allows for converting and compressing one or several file(s) using the context menu.",
     "license": "GPL-3.0",
     "architecture": {


### PR DESCRIPTION
- Due to https://github.com/ScoopInstaller/Nonportable/pull/304#issuecomment-2092893210 also needs update to v2.1 and change to 64bit only
- The project github.com/Tichau/FileConverter links to file-converter.io and vice-versa.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #303

(reopened to trigger GHA manifest validation)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
