### PR TITLE
wireguard-np: add arm64 version

### DIFF
--- a/bucket/wireguard-np.json
+++ b/bucket/wireguard-np.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://download.wireguard.com/windows-client/wireguard-x86-0.5.3.msi#/setup.msi_",
             "hash": "ad1af1ae3474ef35de3809979aee98758430881b270e47e89e027b3490791d0d"
+        },
+        "arm64": {
+            "url": "https://download.wireguard.com/windows-client/wireguard-arm64-0.5.3.msi#/setup.msi_",
+            "hash": "e11f22d22e2e938822c39b88ee04af814b2fb53b70acb00a0bd1bcb2c3f36b1c"
         }
     },
     "installer": {
@@ -45,6 +49,9 @@
             },
             "32bit": {
                 "url": "https://download.wireguard.com/windows-client/wireguard-x86-$version.msi#/setup.msi_"
+            },
+            "arm64": {
+                "url": "https://download.wireguard.com/windows-client/wireguard-arm64-$version.msi#/setup.msi_"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Add an arm64 native version of WG
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
