### PR TITLE
vokoscreenng-np: Exclude non-existent files from post_install deletion

### DIFF
--- a/bucket/vokoscreenng-np.json
+++ b/bucket/vokoscreenng-np.json
@@ -12,7 +12,7 @@
     "post_install": [
         "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
         "Start-Process \"$dir\\setup.exe\" -Wait -Verb 'RunAs' -WindowStyle 'Hidden' -ArgumentList @('in', '-c', '--am', '--al', '-t', \"$dir\")",
-        "Remove-Item \"$dir\\setup.exe\", \"$dir\\vcredist_2010_x64.exe\""
+        "Remove-Item \"$dir\\setup.exe\""
     ],
     "pre_uninstall": [
         "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",


### PR DESCRIPTION
Version 4.1.0 or later distributed with vcredist dll and no longer contains vcredist installer.  
This PR simply remove vcredist installer from removal targets in post_install script.

Affected since: 4.1.0 (and now 4.5.0)

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #298

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
