### PR TITLE
windscribe-np: Add version 2.17.9

### DIFF
--- a/bucket/windscribe-np.json
+++ b/bucket/windscribe-np.json
@@ -14,11 +14,7 @@
     }
   },
   "installer": {
-    "script": [
-      "$exe = Join-Path $dir $fname",
-      "if (!(Test-Path $exe)) { throw \"Installer not found: $exe\" }",
-      "Start-Process -FilePath $exe -ArgumentList '-silent' -Verb RunAs -Wait"
-    ]
+    "args": "-silent"
   },
   "uninstaller": {
     "script": [


### PR DESCRIPTION
* [x]  I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

- Source: https://github.com/Windscribe/Desktop-App (GitHub Releases)
- Hashes: GUI Installer SHA256 (amd64/arm64) from the v2.17.9 release notes
- Install: -silent
- Uninstall: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART (resolved via QuietUninstallString/UninstallString in registry)
- Nonportable: requires elevation
- checkver: "github" + per-arch autoupdate
- Tested in Windows Sandbox: silent install/uninstall; non-blocking (uninstaller is async; registry polling with timeout)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windscribe (Windows) package with silent install/uninstall, automatic elevation when required, and support for x64 and ARM64. Downloads are integrity-checked and auto-update uses GitHub releases.  
  * Uninstall now enforces silent mode, attempts elevation if needed, and waits for completion to ensure clean removal.

* **Documentation**
  * Clarified nonportable packaging and noted a potential feedback page shown after uninstall.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->