### PR TITLE
windscribe-np: Add version 2.19.7

### DIFF
--- a/bucket/windscribe-np.json
+++ b/bucket/windscribe-np.json
@@ -1,33 +1,40 @@
 {
-    "version": "2.17.9",
-    "description": "Windscribe Desktop App (nonportable). Requires administrator privileges.",
-    "homepage": "https://github.com/Windscribe/Desktop-App",
-    "license": "Proprietary",
-    "notes": "This package runs the official vendor installer. Use an elevated PowerShell session (Run as Administrator).",
+    "##": [
+        "The `-dir` option can only install the application on the system drive.",
+        "To avoid unnecessary complexity, please do not use the `-dir` option in the installation script."
+    ],
+    "version": "2.19.7",
+    "description": "A feature-rich VPN desktop application that enhances online privacy by hiding the user's location, blocking ads and trackers, and securing network traffic, with support for multiple modern protocols and advanced networking features.",
+    "homepage": "https://windscribe.com",
+    "license": {
+        "identifier": "GPL-2.0-or-later",
+        "url": "https://github.com/Windscribe/Desktop-App/blob/HEAD/LICENSE"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Windscribe/Desktop-App/releases/download/v2.17.9/Windscribe_2.17.9_amd64.exe",
-            "hash": "91378b0597fa5320c8fe62520e644d5c864d0f7ae1aa7c85e0c772a6b744e867",
-            "installer": {
-                "args": [
-                    "-silent",
-                    "-no-auto-start"
-                ]
-            }
+            "url": "https://github.com/Windscribe/Desktop-App/releases/download/v2.19.7/Windscribe_2.19.7_amd64.exe",
+            "hash": "106505261ee122d4ddbebc09993c3ee7c7962274af013efc684c064f2f4ee5fa"
         },
         "arm64": {
-            "url": "https://github.com/Windscribe/Desktop-App/releases/download/v2.17.9/Windscribe_2.17.9_arm64.exe",
-            "hash": "11091e698096af3b159ed73f891deacc6c46ccdcab0ffd3a1de789b094b0dec0",
-            "installer": {
-                "args": [
-                    "-silent",
-                    "-no-auto-start"
-                ]
-            }
+            "url": "https://github.com/Windscribe/Desktop-App/releases/download/v2.19.7/Windscribe_2.19.7_arm64.exe",
+            "hash": "937676500fb84a4e64c22c3b1fcae7feaf14e8b473d73e5155deba4bf1469bcf"
         }
     },
+    "pre_install": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
+    "installer": {
+        "script": [
+            "$args_list = @('-silent', '-no-auto-start')",
+            "Start-Process -FilePath \"$dir\\$fname\" -ArgumentList $args_list -WindowStyle 'Hidden' -Wait",
+            "Remove-Item -Path \"$dir\\$fname\" -Force -ErrorAction SilentlyContinue"
+        ]
+    },
+    "pre_uninstall": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
     "uninstaller": {
-        "script": "$pf=$env:ProgramFiles; $path=Join-Path $pf 'Windscribe\\uninstall.exe'; if (Test-Path $path) { $p=Start-Process -FilePath $path -ArgumentList '/VERYSILENT' -WorkingDirectory (Split-Path $path) -PassThru -WindowStyle Hidden; $p.WaitForExit() }"
+        "script": [
+            "$install_dir = \"$env:ProgramFiles\\Windscribe\"",
+            "$uninstaller_file = Get-ChildItem -Path $install_dir -Filter 'unins*.exe' -File | Select-Object -ExpandProperty FullName -First 1",
+            "Start-Process -FilePath $uninstaller_file -ArgumentList @('/VERYSILENT') -WindowStyle Hidden -Wait"
+        ]
     },
     "checkver": {
         "github": "https://github.com/Windscribe/Desktop-App"
@@ -35,19 +42,15 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Windscribe/Desktop-App/releases/download/v$version/Windscribe_$version_amd64.exe",
-                "hash": {
-                    "url": "https://github.com/Windscribe/Desktop-App/releases/tag/v$version",
-                    "regex": "Windows\\s*amd64[\\s\\S]*?([A-Fa-f0-9]{64})"
-                }
+                "url": "https://github.com/Windscribe/Desktop-App/releases/download/v$version/Windscribe_$version_amd64.exe"
             },
             "arm64": {
-                "url": "https://github.com/Windscribe/Desktop-App/releases/download/v$version/Windscribe_$version_arm64.exe",
-                "hash": {
-                    "url": "https://github.com/Windscribe/Desktop-App/releases/tag/v$version",
-                    "regex": "Windows\\s*arm64[\\s\\S]*?([A-Fa-f0-9]{64})"
-                }
+                "url": "https://github.com/Windscribe/Desktop-App/releases/download/v$version/Windscribe_$version_arm64.exe"
             }
+        },
+        "hash": {
+            "url": "https://github.com/Windscribe/Desktop-App/releases/tag/v$version",
+            "regex": "(?s)$basename.+?$sha256"
         }
     }
 }


### PR DESCRIPTION
Closes #486

New nonportable manifest for Windscribe Desktop App.
- Uses official GUI installers (x64, arm64)
- Silent install: -silent -no-auto-start
- Uninstall: vendor uninstaller via script with /VERYSILENT
- Version check: checkver "github" (pre-releases ignored)
- Autoupdate: per-arch URLs; hash scraped from tag page

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windscribe Desktop App v2.19.7 support with multi-architecture installers (64-bit and ARM64).
  * Introduced silent install and silent uninstall flows, including pre-install and pre-uninstall admin-rights checks.
  * Enabled automatic update checks with asset integrity verification and automated update handling via release tags.
  * PowerShell-based uninstall flow and guidance to avoid using a custom install-directory option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->