### PR TITLE
auto-dark-mode-np: version 11.0.0.54, removes 32bit, adds 64bit and arm, disables in-app updater

### DIFF
--- a/bucket/auto-dark-mode-np.json
+++ b/bucket/auto-dark-mode-np.json
@@ -19,7 +19,8 @@
             "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
             "if ([Environment]::OSVersion.Version.Major -lt 10) { error \"$app only supports Windows 10\"; break }",
             "Start-Process \"$dir\\setup.exe\" -ArgumentList @('/SP-', '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', \"/DIR=`\"$dir`\"\") -Wait -Verb RunAs | Out-Null",
-            "Remove-Item \"$dir\\setup.exe\""
+            "Remove-Item \"$dir\\setup.exe\"",
+            "Write-Output \"Updater:`n  Enabled: false\" | Out-File -Append -FilePath \"$env:APPDATA\\AutoDarkMode\\config.yaml\" -Encoding Ascii"
         ]
     },
     "uninstaller": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #491

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release to 11.0.0.54.
  * Distribution now provides separate installers and checksums for 64‑bit and ARM64 platforms.
  * Auto-update now uses architecture-specific update resources instead of a single shared entry.
  * Installer now writes updater configuration as part of the install flow after removing the setup executable.
  * Notes, uninstaller and version-check behavior remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->