### PR TITLE
rom-properties-np: Update to version 2.7.1, switch to Inno Setup installer

### DIFF
--- a/bucket/rom-properties-np.json
+++ b/bucket/rom-properties-np.json
@@ -6,6 +6,7 @@
         "identifier": "GPL-2.0-or-later",
         "url": "https://github.com/GerbilSoft/rom-properties/blob/HEAD/LICENSE"
     },
+    "depends": "extras/vcredist2022",
     "url": "https://github.com/GerbilSoft/rom-properties/releases/download/v2.7.1/SetupRomProperties-2.7.1.exe",
     "hash": "17d9e19d3d9d5201c70ab0e1a6b325be7c09e7dfc31b322fc69b73695523a3cc",
     "architecture": {
@@ -37,7 +38,7 @@
             "/NOCANCEL",
             "/NORESTART",
             "/NOICONS",
-            "/DIR=$dir"
+            "/DIR=\"$dir\""
         ]
     },
     "post_install": [


### PR DESCRIPTION
### Related issues or pull requests

- Relates to #548  

### Summary

Update to version 2.7.1 and switch installer/uninstaller logic from .zip to repo's new Windows installer Inno Setup file.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic version detection and GitHub-based updates; autoupdate now targets the new installer naming.
  * Silent installer/uninstaller support with post-install/uninstall actions to refresh the system.
  * arm64 architecture officially supported.
  * Dependency declared on a Visual C++ runtime package.

* **Chores**
  * Bumped release to 2.7.1 and added structured license metadata.
  * Installer/uninstall flow and permission checks streamlined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->