### PR TITLE
nelson-np:  Add version 1.16.0.5575

### DIFF
--- a/bucket/nelson-np.json
+++ b/bucket/nelson-np.json
@@ -16,15 +16,19 @@
             "hash": "ee1042346a3c1ac06003313b83e794180509067c19bec6681e71486fd19d539f"
         }
     },
+    "pre_install": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
     "installer": {
         "script": [
-            "Start-Process -Wait \"$dir\\$fname\" -ArgumentList @('/SP-', \"/DIR=$dir\", '/VERYSILENT', '/SUPPRESSMSGBOXES') -Verb RunAs",
+            "$args_list = @('/SP-', \"/DIR=$dir\", '/VERYSILENT', '/SUPPRESSMSGBOXES')",
+            "Start-Process -FilePath \"$dir\\$fname\" -ArgumentList $args_list -WindowStyle 'Hidden' -Wait",
             "Remove-Item -Path \"$dir\\$fname\" -Force -ErrorAction SilentlyContinue"
         ]
     },
+    "pre_uninstall": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
     "uninstaller": {
         "script": [
-            "Start-Process -Wait \"$dir\\unins000.exe\" -ArgumentList @('/VERYSILENT', '/SUPPRESSMSGBOXES') -Verb RunAs | Out-Null",
+            "$args_list = @('/VERYSILENT', '/SUPPRESSMSGBOXES')",
+            "Start-Process -FilePath \"$dir\\unins000.exe\" -ArgumentList $args_list -WindowStyle 'Hidden' -Wait",
             "Start-Sleep -Seconds 3"
         ]
     },


### PR DESCRIPTION
### Summary

Add a manifest for [nelson-np](https://nelson-lang.github.io/nelson-website/) version 1.16.0.5575.

### Related issues or pull requests

- Closes #534 

### Testing

- [x] `scoop install nelson-np` works without errors
- [x] `nelson.exe` launches successfully
- [x] `scoop uninstall nelson-np` removes all installed files
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Nelson package manifest to enable installation and automatic updates via package managers.
  * Supports 64-bit and arm64 installers with architecture-specific update patterns.
  * Adds silent install/uninstall automation with admin elevation and cleanup.
  * Includes versioning, homepage/description, license metadata, and update-check configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->