### PR TITLE
nvidia-display-driver-dch-np: Update to version 591.86, fix installer, fix checkver

### DIFF
--- a/bucket/nvidia-display-driver-dch-np.json
+++ b/bucket/nvidia-display-driver-dch-np.json
@@ -43,9 +43,9 @@
             "Move-Item \"$dir\\extract\\NvApp\\*.txt\" -Destination \"$dir\\setup\\NvApp\"",
             "",
             "$success = Invoke-ExternalCommand -Path \"$dir\\setup\\setup.exe\" @Args('-s', '-noreboot', \"-log:$dir\\logs\", '-loglevel:4')",
+            "Remove-Item \"$dir\\extract\", \"$dir\\setup\" -Force -Recurse",
             "if (!$success) { error \"setup.exe failed, check logs at '$dir\\logs'\" ; break }",
-            "",
-            "Remove-Item \"$dir\\extract\", \"$dir\\setup\", \"$dir\\logs\" -Force -Recurse"
+            "Remove-Item \"$dir\\logs\" -Force -Recurse"
         ]
     },
     "checkver": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Updates checkver, fixes installer, simplifies installer, updates notes and description.

Closes #393
Closes #506

### Details:
- Copies maintainer notes from `nvidia-display-driver-np.json`
- adds license url
- updates to version 591.86
- Removes the service autostart tracking of `NVDisplay.ContainerLocalSystem` since this caused issues during repeated re-installs and from quick searches is not enough anyway to disable telemetry.
    - Telemetry is not installed, but it is not guaranteed to be fully deactivated.
- Fixed the installer by updating the extracted sub-folders for limited installation and EULA patches from `GFExperience` to `NvApp`
- `NvApp` is not installed, just like `GFExperience` was not installed in previous manifests
- Creates logs during installation for easier error reporting by users
- Updates checkver to use `GeForce RTX 50 Series` when checking for newest versions

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated NVIDIA GeForce driver to v591.86 with refreshed download URL and checksum.
  * Updated product description and added official license URL.

* **Bug Fixes / Improvements**
  * Revamped installer flow to consolidate package contents, improve execution checks, logging and cleanup.
  * Adjusted update lookup and auto-update mapping to match the new package layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->