### PR TITLE
tortoisegit-np: Add version 2.18.0.1

### DIFF
--- a/bucket/tortoisegit-np.json
+++ b/bucket/tortoisegit-np.json
@@ -23,21 +23,24 @@
     "pre_install": "if (!(is_admin)) { error \"Admin rights required to install TortoiseGit\"; break }",
     "installer": {
         "script": [
-            "$succ = Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\dl._msi\", '/passive', '/quiet', '/log', \"$dir\\install.log\")",
+            "$succ = Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\$fname\", '/passive', '/quiet', '/log', \"$dir\\install.log\")",
             "if(-not $succ) {",
             "    Select-String -Path \"$dir\\install.log\" -Pattern \"MSI \\(s\\).*required\" | ForEach-Object { info \"from log: $_\" }",
             "    if (Select-String -Path \"$dir\\install.log\" -Pattern \"latest.*2015-2022 Redistributable\") {",
-            "       info \"Consider installing scoop package 'extras/vcredist2022'\"",
+            "       error \"Missing requirement 'Microsoft Visual C++ Redistributable for Visual Studio 2015-2022'\"",
+            "       info \"consider installing scoop package 'extras/vcredist2022'\"",
             "    }",
-            "    error \"Failed ($succ) to extract files from `\"$dir\\dl._msi`\".`nLog file:`n  $(friendly_path `\"$dir\\install.log`\")\"",
+            "    error \"Failed ($succ) to run `\"$dir\\$fname`\".`nLog file:`n  $(friendly_path `\"$dir\\install.log`\")\"",
             "    break",
             "}"
         ]
     },
-    "post_install": "New-ItemProperty -Path 'HKCU:\\SOFTWARE\\TortoiseGit' -Name 'VersionCheck' -PropertyType DWord -Value 0 -Force | Out-Null",
+    "post_install": [
+        "New-ItemProperty -Path 'HKCU:\\SOFTWARE\\TortoiseGit' -Name 'VersionCheck' -PropertyType DWord -Value 0 -Force | Out-Null"
+    ],
     "pre_uninstall": "if (!(is_admin)) { error \"Admin rights required to uninstall TortoiseGit\"; break }",
     "uninstaller": {
-        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/uninstall', \"$dir\\dl._msi\", '/passive', '/quiet', '/log', \"$dir\\uninstall.log\")"
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/uninstall', \"$dir\\dl._msi\", '/qn', '/log', \"$dir\\uninstall.log\")"
     },
     "checkver": {
         "url": "https://tortoisegit.org/docs/releasenotes/",


### PR DESCRIPTION
Adds TortoiseGit as non-portable.

I investigated the other methods of installing TortoiseGit in a portable way out there, but could not find anything that would allow for easy maintenance or a portable way.

This implementation simply uses the official msi installer. I saw that msi installation has been obsoleted, but I could not figure out why.

Implements `x64` and `arm64`.

Skipped `x86` implementation, because [(source)](https://tortoisegit.org/docs/releasenotes/):
> Git for Windows has stopped providing builds for 32-bit Windows, and TortoiseGit will follow suit with one of the next releases.

Furthermore:
- Closes https://github.com/ScoopInstaller/Extras/issues/1435
- Closes https://github.com/ScoopInstaller/Scoop/issues/2665
- Obsoletes Pull Request https://github.com/ScoopInstaller/Extras/pull/5443
- Relates to Pull Request https://github.com/ScoopInstaller/Extras/pull/1566
- [x] Verified there are no other open issues for this application in scoop
- [x] Verified there are no other open pull requests for this application
- [x] Use conventional PR title
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
- [x] Follows general order of fields and ran `.\bin\formatjson.ps1`
- [x] Tab width 4 spaces

### Checkver OK
```
PS C:\Users\WDAGUtilityAccount\scoop\buckets\nonportable> .\bin\checkver.ps1 tortoisegit-np
tortoisegit-np: 2.18.0.1
```

### Autoupdate OK:
```
PS C:\Users\WDAGUtilityAccount\scoop\buckets\nonportable> .\bin\checkver.ps1 tortoisegit-np -f
tortoisegit-np: 2.18.0.1 (scoop version is 2.18.0.1)
Forcing autoupdate!
Autoupdating tortoisegit-np
DEBUG[1766417091.6511] [$updatedProperties] = [url hash] -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1766417091.79661] $substitutions (hashtable) -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1766417091.79661] $substitutions.$buildVersion                  1                                                                                                                                       
DEBUG[1766417091.79661] $substitutions.$match1                        2.18.0.1                                                                                                                                
DEBUG[1766417091.79661] $substitutions.$preReleaseVersion             2.18.0.1                                                                                                                                
DEBUG[1766417091.79661] $substitutions.$version                       2.18.0.1                                                                                                                                
DEBUG[1766417091.79661] $substitutions.$patchVersion                  0                                                                                                                                       
DEBUG[1766417091.79661] $substitutions.$urlNoExt                      https://download.tortoisegit.org/tgit/2.18.0.0/TortoiseGit-2.18.0.1-64bit                                                               
DEBUG[1766417091.79661] $substitutions.$dotVersion                    2.18.0.1                                                                                                                                
DEBUG[1766417091.79661] $substitutions.$cleanVersion                  21801                                                                                                                                   
DEBUG[1766417091.79661] $substitutions.$underscoreVersion             2_18_0_1                                                                                                                                
DEBUG[1766417091.79661] $substitutions.$minorVersion                  18                                                                                                                                      
DEBUG[1766417091.79661] $substitutions.$url                           https://download.tortoisegit.org/tgit/2.18.0.0/TortoiseGit-2.18.0.1-64bit.msi                                                           
DEBUG[1766417091.79661] $substitutions.$majorVersion                  2                                                                                                                                       
DEBUG[1766417091.79661] $substitutions.$matchTail                     .1                                                                                                                                      
DEBUG[1766417091.79661] $substitutions.$basenameNoExt                 TortoiseGit-2.18.0.1-64bit                                                                                                              
DEBUG[1766417091.79661] $substitutions.$basename                      TortoiseGit-2.18.0.1-64bit.msi                                                                                                          
DEBUG[1766417091.79661] $substitutions.$dashVersion                   2-18-0-1                                                                                                                                
DEBUG[1766417091.79661] $substitutions.$baseurl                       https://download.tortoisegit.org/tgit/2.18.0.0                                                                                          
DEBUG[1766417091.79661] $substitutions.$matchHead                     2.18.0                                                                                                                                  
DEBUG[1766417091.85902] $hashfile_url = $null -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading TortoiseGit-2.18.0.1-64bit.msi to compute hashes!
Loading TortoiseGit-2.18.0.1-64bit.msi from cache
Computed hash: cbf7d52aa0ecca665521e14d8d1a4b6cda52a4bc13de45f49084e15571c77410
DEBUG[1766417091.95266] $substitutions (hashtable) -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1766417091.95266] $substitutions.$buildVersion                  1                                                                                                                                       
DEBUG[1766417091.95266] $substitutions.$match1                        2.18.0.1                                                                                                                                
DEBUG[1766417091.95266] $substitutions.$preReleaseVersion             2.18.0.1                                                                                                                                
DEBUG[1766417091.95266] $substitutions.$version                       2.18.0.1                                                                                                                                
DEBUG[1766417091.95266] $substitutions.$patchVersion                  0                                                                                                                                       
DEBUG[1766417091.95266] $substitutions.$urlNoExt                      https://download.tortoisegit.org/tgit/2.18.0.0/TortoiseGit-2.18.0.1-arm64                                                               
DEBUG[1766417091.95266] $substitutions.$dotVersion                    2.18.0.1                                                                                                                                
DEBUG[1766417091.95266] $substitutions.$cleanVersion                  21801                                                                                                                                   
DEBUG[1766417091.95266] $substitutions.$underscoreVersion             2_18_0_1                                                                                                                                
DEBUG[1766417091.95266] $substitutions.$minorVersion                  18                                                                                                                                      
DEBUG[1766417091.95266] $substitutions.$url                           https://download.tortoisegit.org/tgit/2.18.0.0/TortoiseGit-2.18.0.1-arm64.msi                                                           
DEBUG[1766417091.95266] $substitutions.$majorVersion                  2                                                                                                                                       
DEBUG[1766417091.95266] $substitutions.$matchTail                     .1                                                                                                                                      
DEBUG[1766417091.95266] $substitutions.$basenameNoExt                 TortoiseGit-2.18.0.1-arm64                                                                                                              
DEBUG[1766417091.95266] $substitutions.$basename                      TortoiseGit-2.18.0.1-arm64.msi                                                                                                          
DEBUG[1766417091.95266] $substitutions.$dashVersion                   2-18-0-1                                                                                                                                
DEBUG[1766417091.95266] $substitutions.$baseurl                       https://download.tortoisegit.org/tgit/2.18.0.0                                                                                          
DEBUG[1766417091.95266] $substitutions.$matchHead                     2.18.0                                                                                                                                  
DEBUG[1766417092.01538] $hashfile_url = $null -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading TortoiseGit-2.18.0.1-arm64.msi to compute hashes!
Loading TortoiseGit-2.18.0.1-arm64.msi from cache
Computed hash: d6cc582bb7cdcf57e662861639be8b4d02ed5f75627b04ae2caaea4c7d40658b
Writing updated tortoisegit-np manifest
```

### Confirmed Virustotal OK
https://www.virustotal.com/gui/file/cbf7d52aa0ecca665521e14d8d1a4b6cda52a4bc13de45f49084e15571c77410/details
https://www.virustotal.com/gui/file/d6cc582bb7cdcf57e662861639be8b4d02ed5f75627b04ae2caaea4c7d40658b

### Tests
- [x] disabling autoupdate is successful
- [x] updated from v2.17.0.2 to v2.18.0.1, user settings were kept correctly
- [ ] arm64 install could not be tested, because msi execution is not possible on my x64 setup
- [x] uninstall
- [x] application seems to run fine in a minimal test
- [x] admin installation required, data is stored outside of scoop


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TortoiseGit NP v2.18.0.1 installer package with multi-architecture support (x64 and ARM64).
  * Built-in installer and uninstaller with admin checks, robust error handling, and logging.
  * Automatic version checks and autoupdate configuration for seamless updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->