### PR TITLE
files-np: Update to version 4.0.24.0, fix checkver

### DIFF
--- a/bucket/files-np.json
+++ b/bucket/files-np.json
@@ -1,5 +1,4 @@
 {
-    "##": "Please avoid removing the checkver.url property until https://github.com/ScoopInstaller/Scoop/pull/6490 has been merged into master.",
     "version": "4.0.24.0",
     "homepage": "https://files.community/",
     "description": "A modern file manager that helps users organize their files and folders.",
@@ -18,20 +17,8 @@
         "script": "Get-AppxPackage 'Files' | Remove-AppxPackage"
     },
     "checkver": {
-        "url": "https://github.com/files-community/Files",
-        "script": [
-            "try {",
-            "  $latest = Invoke-WebRequest -Uri 'https://api.github.com/repos/files-community/Files/releases/latest'",
-            "  $tag_name = ($latest.Content | ConvertFrom-Json).tag_name -replace 'v', ''",
-            "  $tag_ver = [System.Version]::Parse($tag_name)",
-            "  $major = if ($tag_ver.Major -eq -1) { 0 } else { $tag_ver.Major }",
-            "  $minor = if ($tag_ver.Minor -eq -1) { 0 } else { $tag_ver.Minor }",
-            "  $build = if ($tag_ver.Build -eq -1) { 0 } else { $tag_ver.Build }",
-            "  $revision = if ($tag_ver.Revision -eq -1) { 0 } else { $tag_ver.Revision }",
-            "  Write-Output \"$major.$minor.$build.$revision\"",
-            "} catch { error $_.Exception.Message; throw }"
-        ],
-        "regex": "(\\d.+)"
+        "url": "https://cdn.files.community/files/stable/Files.Package.appinstaller",
+        "regex": "(?s)MainBundle.*?Version=\"([\\d.]+)\""
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated application version to 4.0.24.0 and provided the new 64-bit/ARM64 installer with updated verification checksum.
  * Simplified update-check mechanism to use the appinstaller feed for version detection.
  * No functional or UI changes in the installer, post-install, or uninstaller behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->