### PR TITLE
calibre-np: deprecate manifest, revert to last working version, fix checkver and autoupdate

### DIFF
--- a/deprecated/calibre-np.json
+++ b/deprecated/calibre-np.json
@@ -1,12 +1,13 @@
 {
-    "version": "8.16.2",
+    "##": "Deprecated. Please use extras/calibre instead.",
+    "version": "6.29.0",
     "description": "E-book manager.",
     "homepage": "https://calibre-ebook.com/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kovidgoyal/calibre/releases/download/v8.16.2/calibre-64bit-8.16.2.msi",
-            "hash": "7f052a6027d2331ce214cd4cbf7d8b12125b39a420309745cc6974cf3a000d50",
+            "url": "https://download.calibre-ebook.com/6.29.0/calibre-64bit-6.29.0.msi",
+            "hash": "58ef95016dafc8616cbadc74ee98a3a21eaf401b6caf110ebc5672392fa48fd4",
             "extract_dir": "PFiles\\Calibre2"
         }
     },
@@ -49,12 +50,13 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/kovidgoyal/calibre"
+        "url": "https://download.calibre-ebook.com/6.html",
+        "regex": "(\\d+\\.\\d+\\.\\d+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-64bit-$version.msi"
+                "url": "https://download.calibre-ebook.com/$version/calibre-64bit-$version.msi"
             }
         }
     }


### PR DESCRIPTION
Deprecates manifest with last working version.

Duplicate manifest, better and updated manifest in: extras/calibre

- adds deprecation note and alternative
- installer has stopped working with v7 and v8 versions of calibre
- reverting to last working version 6.29.0
- fixes checkver and autoupdate to support installation of different v6 versions. Github does not host older installers.

Relates https://github.com/ScoopInstaller/Nonportable/issues/249
Closes https://github.com/ScoopInstaller/Nonportable/issues/266
Closes https://github.com/ScoopInstaller/Nonportable/issues/425

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deprecated manifest configuration with new upstream source information and added deprecation notice.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->