### PR TITLE
mullvadvpn-np: Fixes update bug, switches to github

### DIFF
--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -12,7 +12,8 @@
     "installer": {
         "script": [
             "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-            "Invoke-ExternalCommand \"$dir\\$fname\" -ArgumentList @('/S')"
+            "Invoke-ExternalCommand \"$dir\\$fname\" -ArgumentList @('/S')",
+            "Remove-Item \"$dir\\$fname\""
         ]
     },
     "uninstaller": {


### PR DESCRIPTION
Fixes update bug and improves general manifest

I took a look at the mullvadvpn-np package and performed the following changes:
- Implemented a check to not use the uninstaller, since it deletes the `$env:LocalAppdata\Mullvad VPN` folder, which is used to store the configurations
- Switches to their official github repository for download, checkver and autoupdate, since many issues in the past had to do with changes of their distribution through their website.
- Changed from pre_install and pre_uninstall to installer and uninstaller to make the manifest more standardized
- Switches to scoop's simpler `Invoke-ExternalCommand` to get rid of the custom process and daemon checks
- switches to the smaller `x64` installer, that is also being used by Chocolatey

Tests:
- Updates with the new manifest tested
- In-App update also works and is compatible with scoop. I could not find a way to disable the in-app update
- Virustotal is ok with 0/97: https://www.virustotal.com/gui/url/c8179b696cf5eb6f7023dc2b76245bc18a2bc7628250400172989cca34bdb5b1/details

Closes https://github.com/ScoopInstaller/Nonportable/issues/364 :
- Does not execute the uninstaller when updating. Verified it works.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated installation and uninstallation procedures
  * Migrated package distribution and auto-update delivery to GitHub releases
  * Modified version detection mechanism

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->