### PR TITLE
textpad-np: deprecates manifest

### DIFF
--- a/deprecated/textpad-np.json
+++ b/deprecated/textpad-np.json
@@ -1,4 +1,5 @@
 {
+    "##": "Deprecated manifest, please download directly from textpad.com",
     "version": "9.6.1",
     "description": "A powerful, general purpose editor for plain text files.",
     "homepage": "https://www.textpad.com/",
@@ -16,8 +17,8 @@
         "script": "Start-Process -Wait 'msiexec' -ArgumentList @('/x', '{0BCB93E1-6EB3-430A-8F78-5D0069309DB3}', '/qn') -Verb RunAs | Out-Null"
     },
     "checkver": {
-        "url": "https://www.textpad.com/download",
-        "regex": ">TextPad (9[\\d.]+)\\s*"
+        "url": "https://www.textpad.com/relnotes-textpad",
+        "regex": "TextPad (\\d+\\.\\d+\\.\\d+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
deprecates textpad-np, because the download links are now captcha-protected

- Download links are now custom-captcha protected, which can't be handled in scoop. Chocolatey uses a custom captcha solver: [link](https://github.com/shiitake/have-some-chocolate/blob/master/TextPad/v9/tools/chocolateyinstall.ps1)
- There is also no mirror from the waybackmachine sadly
- fixed checkver

Closes [#376](https://github.com/ScoopInstaller/Nonportable/issues/376)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Marked TextPad manifest as deprecated with a notice directing users to download directly from the official source.
  * Updated version detection configuration for improved accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->