### PR TITLE
resilio-sync-np@3.1.2.1076: new version, updated checkver, autoupdate and (un)installer

### DIFF
--- a/bucket/resilio-sync-np.json
+++ b/bucket/resilio-sync-np.json
@@ -25,7 +25,9 @@
         "script": [
             "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
             "$cec = @{1 = 'You may need to restart your PC for the app to be completely removed'}",
-            "Invoke-ExternalCommand \"$Env:AppData\\Resilio Sync\\Resilio Sync.exe\" -ArgumentList @('/UNINSTALL', '/S', '/REMSETTINGS') -ContinueExitCodes $cec"
+            "$args = @('/UNINSTALL', '/S')",
+            "if ($cmd -ne 'update') { $args += '/REMSETTINGS' }",
+            "Invoke-ExternalCommand \"$Env:AppData\\Resilio Sync\\Resilio Sync.exe\" -ArgumentList $args -ContinueExitCodes $cec"
         ]
     },
     "checkver": {


### PR DESCRIPTION
Updates from v2 to v3

- Updates from major version v2 to v3
- removes 32bit, as it is no longer provided
- adapts installer to new major version silent installation
- Changes checkver, because host blocks automated installers
- Changes autoupdate on a best guess, but their download link structure changes quite often [link](https://sync-forums.resilioservices.com/tags/build/)

Closes #341 
Closes #414 
Closes #504

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 3.1.2.1076 (previously 2.8.1.1390).
  * Refined installer and update mechanism configuration.
  * Optimized version detection and autoupdate source.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->