### PR TITLE
goodsync-np: changed to shareware

### DIFF
--- a/bucket/goodsync-np.json
+++ b/bucket/goodsync-np.json
@@ -3,7 +3,7 @@
     "homepage": "https://www.goodsync.com",
     "description": "Simple and secure file backup/synchronization software.",
     "license": {
-        "identifier": "Freeware",
+        "identifier": "Shareware",
         "url": "https://www.goodsync.com/license"
     },
     "url": "https://www.goodsync.com/download/GoodSync-Setup.exe",


### PR DESCRIPTION
changed license identifier to "Shareware"

Closes: https://github.com/ScoopInstaller/Nonportable/issues/371

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated product licensing classification from Freeware to Shareware.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->