### PR TITLE
lav-filters-megamix-np: deprecates 32bit, fixes urls, updates to v0.81.0-1, adds admin-checks

### DIFF
--- a/bucket/lav-filters-megamix-np.json
+++ b/bucket/lav-filters-megamix-np.json
@@ -23,7 +23,7 @@
     },
     "checkver": {
         "url": "https://www.videohelp.com/software/LAV-Filters-Megamix/old-versions",
-        "regex": "https:\/\/www\\.videohelp\\.com/download/Megamix-LAVFilters-(?<version>\\d+\\.\\d+\\.\\d+(?:-\\d+))-x64\\.exe"
+        "regex": "https://www\\.videohelp\\.com/download/Megamix-LAVFilters-(?<version>\\d+\\.\\d+\\.\\d+(?:-\\d+))-x64\\.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
deprecates 32bit, fixes urls, updates to v0.81.0-1, adds admin-checks

Closes #531 
Closes #528 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Version updated to 0.81.0-1 with a new 64-bit installer package and updated download/hash.
  * 32‑bit support discontinued; 64‑bit only.
  * Admin rights are now required to install and uninstall.
  * Update checks adjusted to track the appropriate release channel and align autoupdate behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->