### PR TITLE
sandboxie-classic-np: Update to version 5.71.9, drop 32-bit version

### DIFF
--- a/bucket/sandboxie-classic-np.json
+++ b/bucket/sandboxie-classic-np.json
@@ -1,6 +1,6 @@
 {
     "##": "For command-line usage, see: https://sandboxie-plus.com/sandboxie/startcommandline/",
-    "version": "5.70.12",
+    "version": "5.71.9",
     "description": "Sandbox isolation software (classic variant)",
     "homepage": "https://sandboxie-plus.com/",
     "license": "GPL-3.0-or-later",
@@ -10,12 +10,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.15.12/Sandboxie-Classic-x64-v5.70.12.exe#/setup.exe",
-            "hash": "ff75aea3627bdec7b39683ff426eefe506ba8dbf983525e38720c152f52f0b9b"
-        },
-        "32bit": {
-            "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.15.12/Sandboxie-Classic-x86-v5.70.12.exe#/setup.exe",
-            "hash": "1c87774f08b4c72d15ace03d728aefc024d78ff6396f1233630909aa5b2e1a7c"
+            "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/Sandboxie-Classic-x64-v5.71.9.exe#/setup.exe",
+            "hash": "3ca95aae7316a892f10b911e852242f020214018c533ab9ecb86b1a80f07a86c"
         }
     },
     "installer": {
@@ -39,10 +35,10 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/v$matchPlusver/Sandboxie-Classic-x64-v$version.exe#/setup.exe"
-            },
-            "32bit": {
-                "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/v$matchPlusver/Sandboxie-Classic-x86-v$version.exe#/setup.exe"
             }
+        },
+        "hash": {
+            "url": "$baseurl/sha256-checksums.txt"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

update to 5.71.9, and remove 32-bit support to fix autoupdate, as 32-bit support has been dropped since [Sandboxie-Classic 5.71.1](https://github.com/sandboxie-plus/Sandboxie/blob/master/CHANGELOG.md#1161--5711---2025-07-06).

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sandboxie-Classic to version 5.71.9
  * Dropped support for 32-bit architecture
  * Updated auto-update configuration and checksum verification

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->