### PR TITLE
virtualbox(-with-extension-pack)-np: Update to version 7.2.4.170995, fix autoupdate & installation

### DIFF
--- a/bucket/virtualbox-np.json
+++ b/bucket/virtualbox-np.json
@@ -27,9 +27,6 @@
             "Remove-Item -Path @(\"$dir\\VirtualBox-*64.msi\", \"$dir\\common.cab\")",
             "if (-not $succ) {",
             "   Select-String -Path \"$dir\\install-log.txt\" -Pattern 'MSI \\(.*' | ForEach-Object { warn \"from log:`n    $_\" }",
-            "   if (Select-String -Path \"$dir\\install-log.txt\" -Pattern 'needs.*2019 Redistributable' ) {",
-            "       info \"Consider installing scoop package 'extras/vcredist2022'\"",
-            "   }",
             "   error \"Failed ($succ) to install `\"$($setup.FullName)`\".`nLog file: `\"$dir\\install-log.txt`\"\"",
             "   break",
             "}"

--- a/bucket/virtualbox-with-extension-pack-np.json
+++ b/bucket/virtualbox-with-extension-pack-np.json
@@ -41,9 +41,6 @@
             "Remove-Item -Path @(\"$dir\\VirtualBox-*64.msi\", \"$dir\\common.cab\")",
             "if (-not $succ) {",
             "   Select-String -Path \"$dir\\install-log.txt\" -Pattern 'MSI \\(.*' | ForEach-Object { warn \"from log:`n    $_\" }",
-            "   if (Select-String -Path \"$dir\\install-log.txt\" -Pattern 'needs.*2019 Redistributable' ) {",
-            "       info \"Consider installing scoop package 'extras/vcredist2022'\"",
-            "   }",
             "   error \"Failed ($succ) to install `\"$($setup.FullName)`\".`nLog file: `\"$dir\\install-log.txt`\"\"",
             "   break",
             "}"


### PR DESCRIPTION
Makes VirtualBox work again

- Closes: https://github.com/ScoopInstaller/Nonportable/issues/179
- Closes: https://github.com/ScoopInstaller/Nonportable/issues/346
- Closes: https://github.com/ScoopInstaller/Nonportable/issues/259
- Closes: https://github.com/ScoopInstaller/Nonportable/issues/463
- Closes: https://github.com/ScoopInstaller/Nonportable/issues/145
- Closes: https://github.com/ScoopInstaller/Nonportable/issues/180
- Closes: https://github.com/ScoopInstaller/Nonportable/issues/302
- Closes: https://github.com/ScoopInstaller/Nonportable/issues/256
- Closes: https://github.com/ScoopInstaller/Nonportable/issues/502

Changes:

#### Switches version number scheme from "7.2.4" to "7.2.4.170995"
This was done, because the build number is necessary for installing and also previous version support.

#### Suggests
vcredist2022 is necessary during installation and runtime

#### pre_install phase
- admin rights are required, even for the setup.exe that just needs to be unpacked
- `setup.exe -extract` step is necessary for silent install as well as local installation through msi later

#### installer phase
- ⚠️ There is an arm64 msi in there, but since the outer exe file is 64-bit only I don't see how to make use of it
- allows for local admin install as well as global installation
- warns about missing vcredist during installation (is an installation & runtime requirement)
- msi install does not support global scoop folder installation, which is why we have to use `$env:ProgramW6432\Oracle\VirtualBox`


#### post-install phase
- implements shims and shortcut in script rather than manifest to support global mode. Sometimes the binaries changed between releases - this is now also supported.
- Folder permissions get modified by the MSI installer, which is why previously the script allowed full access to all users with `icacls -ArgumentList @(\"`\"$dir`\"\", '/grant', 'Everyone:F', '/T')`. This has been changed to reset folder permission, to allow set default inheritance again. This change is more secure and testing showed it works fine, even if non-admin users are using the program.
- shim removal is done via file lookup rather than `scoop shim list` because the package source for global installations is `External` and therefor not clearly searchable for this package.

#### uninstaller phase
- switched from `wmic` to `Get-CimInstance Win32_Product` to be more backward compatible

### with-extensionpack specific

#### post-install phase
- implemented automatic extensionpack installation

#### pre-uninstall phase
- implements extensionpack uninstallation (only needed for global installation)



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MSI-based installer with per-user vs system-wide handling, admin checks, Start menu shortcuts, executable shims, integrated Extension Pack install/uninstall, and Visual C++ 2022 runtime declared as a dependency.

* **Bug Fixes**
  * More reliable uninstall via MSI lookup, enhanced logging, targeted cleanup and failure reporting.

* **Chores**
  * Version bumped to 7.2.4.170995; updated update-check and autoupdate URL/version handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->