### PR TITLE
sandboxie-(classic|plus): Update checkver & autoupdate, refactor script logic

### DIFF
--- a/bucket/sandboxie-classic-np.json
+++ b/bucket/sandboxie-classic-np.json
@@ -1,12 +1,15 @@
 {
     "##": "For command-line usage, see: https://sandboxie-plus.com/sandboxie/startcommandline/",
     "version": "5.71.9",
-    "description": "Sandbox isolation software (classic variant)",
-    "homepage": "https://sandboxie-plus.com/",
-    "license": "GPL-3.0-or-later",
+    "description": "A sandbox-based isolation tool for Windows that runs applications in a controlled environment, preventing permanent changes to the system.",
+    "homepage": "https://sandboxie-plus.com",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/sandboxie-plus/Sandboxie/blob/HEAD/LICENSE.Classic"
+    },
     "notes": [
-        "You are installing Sandboxie Classic, which is designed to be compatible with the original Sandboxie.",
-        "For more new features, install 'sandboxie-plus-np'"
+        "You are installing Sandboxie Classic, which is intended to maintain compatibility with the original Sandboxie.",
+        "For access to newer features and enhancements, please install 'sandboxie-plus-np'."
     ],
     "architecture": {
         "64bit": {
@@ -14,27 +17,23 @@
             "hash": "3ca95aae7316a892f10b911e852242f020214018c533ab9ecb86b1a80f07a86c"
         }
     },
+    "pre_install": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
     "installer": {
-        "script": [
-            "if (!(is_admin)) { error \"$app requires admin rights to install\"; break }",
-            "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList '/S' -RunAs | Out-Null"
-        ]
+        "script": "Start-Process -FilePath \"$dir\\setup.exe\" -ArgumentList @('/S') -WindowStyle 'Hidden' -Wait"
     },
+    "pre_uninstall": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
     "uninstaller": {
-        "script": [
-            "if (!(is_admin)) { error \"$app requires admin rights to uninstall\"; break }",
-            "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList @('/remove', '/S') -RunAs | Out-Null"
-        ]
+        "script": "Start-Process -FilePath \"$dir\\setup.exe\" -ArgumentList @('/remove', '/S') -WindowStyle 'Hidden' -Wait"
     },
     "checkver": {
-        "github": "https://github.com/sandboxie-plus/Sandboxie",
-        "regex": "Release v(?<plusver>[\\d.]+) / (?<classicver>[\\d.]+)",
-        "replace": "${classicver}"
+        "url": "https://api.github.com/repositories/254327261/releases/latest",
+        "jsonpath": "$.assets[?(@.name =~ /Classic/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/Sandboxie-Classic-x64-v([\\d.]+)\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/v$matchPlusver/Sandboxie-Classic-x64-v$version.exe#/setup.exe"
+                "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/$matchTag/Sandboxie-Classic-x64-v$version.exe#/setup.exe"
             }
         },
         "hash": {

--- a/bucket/sandboxie-plus-np.json
+++ b/bucket/sandboxie-plus-np.json
@@ -1,36 +1,36 @@
 {
-    "##": [
-        "For command-line usage, see: https://sandboxie-plus.com/sandboxie/startcommandline/",
-        "The installer is made with InnoSetup, but the app will not work without installing the drivers (via the installer)"
-    ],
     "version": "1.16.9",
-    "description": "Sandbox isolation software (plus variant)",
-    "homepage": "https://sandboxie-plus.com/",
-    "license": "GPL-3.0-or-later",
+    "description": "An enhanced edition of Sandboxie that provides sandbox-based application isolation on Windows with additional features and a modern interface.",
+    "homepage": "https://sandboxie-plus.com",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://github.com/sandboxie-plus/Sandboxie/blob/HEAD/LICENSE.Plus"
+    },
+    "notes": [
+        "If RamDisk or Encrypted Sandboxes are required, the ImDisk driver must be installed.",
+        "",
+        "For command-line usage, see: https://sandboxie-plus.com/sandboxie/startcommandline/.",
+        "Please note that `sandboxie-start` should be used instead of the `start` command mentioned in the documentation."
+    ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/Sandboxie-Plus-x64-v1.16.9.exe#/setup.exe",
+            "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/Sandboxie-Plus-x64-v1.16.9.exe",
             "hash": "435202099f37aec373a9bbb6d734e71a7b567479a7a5aef9a0ac55e3237159a0"
         },
         "arm64": {
-            "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/Sandboxie-Plus-ARM64-v1.16.9.exe#/setup.exe",
+            "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/Sandboxie-Plus-ARM64-v1.16.9.exe",
             "hash": "e05d4894e6c3ab51ff653cf2c8ace73018fd81f5d4a73b88d8f6022cfd3e8dc3"
         }
     },
+    "pre_install": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
     "installer": {
         "script": [
-            "if (!(is_admin)) { error \"$app requires admin rights to install\"; break }",
-            "Start-Process \"$dir\\setup.exe\" -ArgumentList @('/verysilent', \"/dir=`\"$dir`\"\") -Wait -Verb RunAs | Out-Null",
-            "Remove-Item \"$([Environment]::GetFolderPath('commonstartmenu'))\\Programs\\Sandboxie-Plus\" -Recurse",
-            "Remove-Item \"$([Environment]::GetFolderPath('Desktop'))\\Sandboxie-Plus.lnk\"",
-            "Remove-Item \"$dir\\setup.exe\""
-        ]
-    },
-    "pre_uninstall": "Stop-Process -Name 'SbieSvc' -Force -ErrorAction SilentlyContinue",
-    "uninstaller": {
-        "script": [
-            "if (!(is_admin)) { error \"$app requires admin rights to uninstall\"; break }",
-            "Invoke-ExternalCommand \"$dir\\unins000.exe\" -ArgumentList '/verysilent' -RunAs | Out-Null"
+            "$args_list = @('/verysilent', \"/dir=`\"$dir`\"\")",
+            "Start-Process -FilePath \"$dir\\$fname\" -ArgumentList $args_list -WindowStyle 'Hidden' -Wait",
+            "@(",
+            "    \"$dir\\$fname\", \"$env:USERPROFILE\\Desktop\\Sandboxie-Plus.lnk\"",
+            "    \"$([Environment]::GetFolderPath('CommonStartMenu'))\\Programs\\Sandboxie-Plus\"",
+            ") | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue"
         ]
     },
     "bin": [
@@ -42,35 +42,48 @@
     "shortcuts": [
         [
             "SandMan.exe",
-            "Sandboxie-Plus"
+            "Sandboxie-Plus\\Sandboxie-Plus"
         ],
         [
             "Start.exe",
-            "Sandboxie Start Menu",
-            "/box:__ask__ start_menu"
-        ],
-        [
-            "Start.exe",
-            "Run any program sandboxed",
+            "Sandboxie-Plus\\Run any program sandboxed",
             "/box:__ask__ run_dialog"
         ],
         [
             "Start.exe",
-            "Run Web browser sandboxed",
+            "Sandboxie-Plus\\Run Web browser sandboxed",
             "default_browser"
+        ],
+        [
+            "Start.exe",
+            "Sandboxie-Plus\\Run Windows Explorer sandboxed",
+            "."
+        ],
+        [
+            "Start.exe",
+            "Sandboxie-Plus\\Sandboxie Start Menu",
+            "/box:__ask__ start_menu"
         ]
     ],
+    "pre_uninstall": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name 'SbieSvc' -Force -ErrorAction SilentlyContinue; Start-Sleep -Milliseconds 1500",
+            "Start-Process -FilePath \"$dir\\unins000.exe\" -ArgumentList @('/verysilent') -WindowStyle 'Hidden' -Wait"
+        ]
+    },
     "checkver": {
-        "github": "https://github.com/sandboxie-plus/Sandboxie",
-        "regex": "Release v([\\d.]+) / (?<classicver>[\\d.]+)"
+        "url": "https://api.github.com/repositories/254327261/releases/latest",
+        "jsonpath": "$.assets[?(@.name =~ /Plus/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/Sandboxie-Plus-(?:x|ARM)64-v([\\d.]+)\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/v$version/Sandboxie-Plus-x64-v$version.exe#/setup.exe"
+                "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/$matchTag/Sandboxie-Plus-x64-v$version.exe"
             },
             "arm64": {
-                "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/v$version/Sandboxie-Plus-ARM64-v$version.exe#/setup.exe"
+                "url": "https://github.com/sandboxie-plus/Sandboxie/releases/download/$matchTag/Sandboxie-Plus-ARM64-v$version.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
### Summary

Refactors `sandboxie-classic-np` and `sandboxie-plus-np` manifests to improve security handling, modernize installation scripts, and optimize the auto-update mechanism using the GitHub API.

### Changes

- **Enhance metadata and documentation**:
  - Refine `description` for better clarity and updated `license` fields to include variant-specific source URLs.
  - Add comprehensive `notes` regarding command-line usage, ImDisk driver requirements, and the `sandboxie-start` binary naming convention.
- **Standardize admin privilege checks**: Move administrator validation to `pre_install` and `pre_uninstall` using `abort` for cleaner error handling.
- **Modernize installation scripts**: 
  - Replace `Invoke-ExternalCommand` with `Start-Process` for better execution control.
- **Optimize `checkver` and `autoupdate`**: 
  - Switch to GitHub API with `jsonpath` to accurately detect assets for both Classic and Plus variants.
  - Implement `matchTag` to handle releases where the tag name might differ from the version string.
- **Improve uninstallation reliability**: 
  - Add explicit `SbieSvc` process termination and a `Start-Sleep` delay in the Plus variant to release file locks.
  - Ensure residual desktop shortcuts and start menu entries are cleaned up.
- **Refine shortcuts**: Added essential utility shortcuts, including "Windows Explorer sandboxed", and organized them into structured subfolders.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App sandboxie-* -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket' -f
sandboxie-classic-np: 5.71.9 (scoop version is 5.71.9)
Forcing autoupdate!
Autoupdating sandboxie-classic-np
DEBUG[1768756242] [$updatedProperties] = [hash url] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1768756242] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1768756242] $substitutions.$matchTail
DEBUG[1768756242] $substitutions.$patchVersion                  9
DEBUG[1768756242] $substitutions.$baseurl                       https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9
DEBUG[1768756242] $substitutions.$basename                      Sandboxie-Classic-x64-v5.71.9.exe
DEBUG[1768756242] $substitutions.$cleanVersion                  5719
DEBUG[1768756242] $substitutions.$minorVersion                  71
DEBUG[1768756242] $substitutions.$basenameNoExt                 Sandboxie-Classic-x64-v5.71.9
DEBUG[1768756242] $substitutions.$url                           https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/Sandboxie-Classic-x64-v5.71.9.exe
DEBUG[1768756242] $substitutions.$preReleaseVersion             5.71.9
DEBUG[1768756242] $substitutions.$matchTag                      v1.16.9
DEBUG[1768756242] $substitutions.$match1                        5.71.9
DEBUG[1768756242] $substitutions.$buildVersion
DEBUG[1768756242] $substitutions.$version                       5.71.9
DEBUG[1768756242] $substitutions.$majorVersion                  5
DEBUG[1768756242] $substitutions.$dashVersion                   5-71-9
DEBUG[1768756242] $substitutions.$dotVersion                    5.71.9
DEBUG[1768756242] $substitutions.$underscoreVersion             5_71_9
DEBUG[1768756242] $substitutions.$matchHead                     5.71.9
DEBUG[1768756242] $substitutions.$urlNoExt                      https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/Sandboxie-Classic-x64-v5.71.9
DEBUG[1768756242] $hashfile_url = https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/sha256-checksums.txt -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for Sandboxie-Classic-x64-v5.71.9.exe in https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/sha256-checksums.txt
DEBUG[1768756243] $filenameRegex = ([a-fA-F0-9]{32,128})[\x20\t]+.*Sandboxie-Classic-x64-v5\.71\.9\.exe(?:\s|$)|Sandboxie-Classic-x64-v5\.71\.9\.exe[\x20\t]+.*?([a-fA-F0-9]{32,128}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:101:13
Found: 3ca95aae7316a892f10b911e852242f020214018c533ab9ecb86b1a80f07a86c using Extract Mode
Writing updated sandboxie-classic-np manifest
sandboxie-plus-np: 1.16.9 (scoop version is 1.16.9)
Forcing autoupdate!
Autoupdating sandboxie-plus-np
DEBUG[1768756243] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1768756243] $substitutions.$matchTail
DEBUG[1768756243] $substitutions.$patchVersion                  9
DEBUG[1768756243] $substitutions.$baseurl                       https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9
DEBUG[1768756243] $substitutions.$basename                      Sandboxie-Plus-ARM64-v1.16.9.exe
DEBUG[1768756243] $substitutions.$cleanVersion                  1169
DEBUG[1768756243] $substitutions.$minorVersion                  16
DEBUG[1768756243] $substitutions.$basenameNoExt                 Sandboxie-Plus-ARM64-v1.16.9
DEBUG[1768756243] $substitutions.$url                           https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/Sandboxie-Plus-ARM64-v1.16.9.exe
DEBUG[1768756243] $substitutions.$preReleaseVersion             1.16.9
DEBUG[1768756243] $substitutions.$matchTag                      v1.16.9
DEBUG[1768756243] $substitutions.$match1                        1.16.9
DEBUG[1768756243] $substitutions.$buildVersion
DEBUG[1768756243] $substitutions.$version                       1.16.9
DEBUG[1768756243] $substitutions.$majorVersion                  1
DEBUG[1768756243] $substitutions.$dashVersion                   1-16-9
DEBUG[1768756243] $substitutions.$dotVersion                    1.16.9
DEBUG[1768756243] $substitutions.$underscoreVersion             1_16_9
DEBUG[1768756243] $substitutions.$matchHead                     1.16.9
DEBUG[1768756243] $substitutions.$urlNoExt                      https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/Sandboxie-Plus-ARM64-v1.16.9
DEBUG[1768756243] $hashfile_url = https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/sha256-checksums.txt -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for Sandboxie-Plus-ARM64-v1.16.9.exe in https://github.com/sandboxie-plus/Sandboxie/releases/download/v1.16.9/sha256-checksums.txt
DEBUG[1768756244] $filenameRegex = ([a-fA-F0-9]{32,128})[\x20\t]+.*Sandboxie-Plus-ARM64-v1\.16\.9\.exe(?:\s|$)|Sandboxie-Plus-ARM64-v1\.16\.9\.exe[\x20\t]+.*?([a-fA-F0-9]{32,128}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:101:13
Found: e05d4894e6c3ab51ff653cf2c8ace73018fd81f5d4a73b88d8f6022cfd3e8dc3 using Extract Mode
Writing updated sandboxie-plus-np manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/sandboxie-classic-np
Installing 'sandboxie-classic-np' (5.71.9) [64bit] from 'Unofficial' bucket
Loading Sandboxie-Classic-x64-v5.71.9.exe from cache.
Checking hash of Sandboxie-Classic-x64-v5.71.9.exe... OK.
Running pre_install script... Done.
Running installer script... Done.
Linking D:\Software\Scoop\Local\apps\sandboxie-classic-np\current => D:\Software\Scoop\Local\apps\sandboxie-classic-np\5.71.9
'sandboxie-classic-np' (5.71.9) was installed successfully!
Notes
-----
You are installing Sandboxie Classic, which is intended to maintain compatibility with the original Sandboxie.
For access to newer features and enhancements, please install 'sandboxie-plus-np'.
-----

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop update sandboxie-classic-np -f
sandboxie-classic-np: 5.71.9 -> 5.71.9
Updating one outdated app:
Updating 'sandboxie-classic-np' (5.71.9 -> 5.71.9)
Downloading new version
Loading Sandboxie-Classic-x64-v5.71.9.exe from cache.
Checking hash of Sandboxie-Classic-x64-v5.71.9.exe... OK.
Running pre_uninstall script... Done.
Uninstalling 'sandboxie-classic-np' (5.71.9)
Running uninstaller script... Done.
Unlinking D:\Software\Scoop\Local\apps\sandboxie-classic-np\current
Installing 'sandboxie-classic-np' (5.71.9) [64bit] from 'Unofficial' bucket
Loading Sandboxie-Classic-x64-v5.71.9.exe from cache.
Running pre_install script... Done.
Running installer script... Done.
Linking D:\Software\Scoop\Local\apps\sandboxie-classic-np\current => D:\Software\Scoop\Local\apps\sandboxie-classic-np\5.71.9
'sandboxie-classic-np' (5.71.9) was installed successfully!
Notes
-----
You are installing Sandboxie Classic, which is intended to maintain compatibility with the original Sandboxie.
For access to newer features and enhancements, please install 'sandboxie-plus-np'.
-----

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop uninstall sandboxie-classic-np -p
Uninstalling 'sandboxie-classic-np' (5.71.9).
Running pre_uninstall script... Done.
Running uninstaller script... Done.
Unlinking D:\Software\Scoop\Local\apps\sandboxie-classic-np\current
Removing older version (_5.71.9.old).
Removing persisted data.
'sandboxie-classic-np' was uninstalled.

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/sandboxie-plus-np
Installing 'sandboxie-plus-np' (1.16.9) [64bit] from 'Unofficial' bucket
Loading Sandboxie-Plus-x64-v1.16.9.exe from cache.
Checking hash of Sandboxie-Plus-x64-v1.16.9.exe... OK.
Running pre_install script... Done.
Running installer script... Done.
Linking D:\Software\Scoop\Local\apps\sandboxie-plus-np\current => D:\Software\Scoop\Local\apps\sandboxie-plus-np\1.16.9
Creating shim for 'sandboxie-start'.
Making D:\Software\Scoop\Local\shims\sandboxie-start.exe a GUI binary.
Creating shortcut for Sandboxie-Plus\Sandboxie-Plus (SandMan.exe)
Creating shortcut for Sandboxie-Plus\Run any program sandboxed (Start.exe)
Creating shortcut for Sandboxie-Plus\Run Web browser sandboxed (Start.exe)
Creating shortcut for Sandboxie-Plus\Run Windows Explorer sandboxed (Start.exe)
Creating shortcut for Sandboxie-Plus\Sandboxie Start Menu (Start.exe)
'sandboxie-plus-np' (1.16.9) was installed successfully!
Notes
-----
If RamDisk or Encrypted Sandboxes are required, the ImDisk driver must be installed.

For command-line usage, see: https://sandboxie-plus.com/sandboxie/startcommandline/.
Please note that `sandboxie-start` should be used instead of the `start` command mentioned in the documentation.
-----

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop update sandboxie-plus-np -f
sandboxie-plus-np: 1.16.9 -> 1.16.9
Updating one outdated app:
Updating 'sandboxie-plus-np' (1.16.9 -> 1.16.9)
WARN  The following instances of "sandboxie-plus-np" are still running. Scoop is configured to ignore this condition.

 NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
 ------    -----      -----     ------      --  -- -----------
     17     3.14       9.84       0.62    4596   0 SbieSvc

Downloading new version
Loading Sandboxie-Plus-x64-v1.16.9.exe from cache.
Checking hash of Sandboxie-Plus-x64-v1.16.9.exe... OK.
Running pre_uninstall script... Done.
Uninstalling 'sandboxie-plus-np' (1.16.9)
Running uninstaller script... Done.
Removing shim 'sandboxie-start.shim'.
Removing shim 'sandboxie-start.exe'.
Unlinking D:\Software\Scoop\Local\apps\sandboxie-plus-np\current
Installing 'sandboxie-plus-np' (1.16.9) [64bit] from 'Unofficial' bucket
Loading Sandboxie-Plus-x64-v1.16.9.exe from cache.
Running pre_install script... Done.
Running installer script... Done.
Linking D:\Software\Scoop\Local\apps\sandboxie-plus-np\current => D:\Software\Scoop\Local\apps\sandboxie-plus-np\1.16.9
Creating shim for 'sandboxie-start'.
Making D:\Software\Scoop\Local\shims\sandboxie-start.exe a GUI binary.
Creating shortcut for Sandboxie-Plus\Sandboxie-Plus (SandMan.exe)
Creating shortcut for Sandboxie-Plus\Run any program sandboxed (Start.exe)
Creating shortcut for Sandboxie-Plus\Run Web browser sandboxed (Start.exe)
Creating shortcut for Sandboxie-Plus\Run Windows Explorer sandboxed (Start.exe)
Creating shortcut for Sandboxie-Plus\Sandboxie Start Menu (Start.exe)
'sandboxie-plus-np' (1.16.9) was installed successfully!
Notes
-----
If RamDisk or Encrypted Sandboxes are required, the ImDisk driver must be installed.

For command-line usage, see: https://sandboxie-plus.com/sandboxie/startcommandline/.
Please note that `sandboxie-start` should be used instead of the `start` command mentioned in the documentation.
-----

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─>  scoop uninstall sandboxie-plus-np -p
Uninstalling 'sandboxie-plus-np' (1.16.9).
Running pre_uninstall script... Done.
WARN  The following instances of "sandboxie-plus-np" are still running. Scoop is configured to ignore this condition.

 NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
 ------    -----      -----     ------      --  -- -----------
     17     3.15       9.63       0.09   21360   0 SbieSvc

Running uninstaller script... Done.
Removing shim 'sandboxie-start.shim'.
Removing shim 'sandboxie-start.exe'.
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\Sandboxie-Plus\Sandboxie-Plus.lnk
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\Sandboxie-Plus\Run any program sandboxed.lnk
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\Sandboxie-Plus\Run Web browser sandboxed.lnk
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\Sandboxie-Plus\Run Windows Explorer sandboxed.lnk
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\Sandboxie-Plus\Sandboxie Start Menu.lnk
Unlinking D:\Software\Scoop\Local\apps\sandboxie-plus-np\current
Removing older version (_1.16.9.old).
Removing persisted data.
'sandboxie-plus-np' was uninstalled.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced admin rights enforcement during installation and uninstallation processes for both Sandboxie Classic and Plus versions.
  * Improved version detection mechanism for more reliable automatic updates.
  * Added expanded product documentation and licensing information.

* **Chores**
  * Updated product metadata with detailed descriptions and structured license information.
  * Reorganized shortcuts and installation workflows for better user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->