### PR TITLE
devtoys-np: improves (un)installer, adds dependency, adds 64bit and arm64, converted to user-install

### DIFF
--- a/bucket/devtoys-np.json
+++ b/bucket/devtoys-np.json
@@ -39,9 +39,9 @@
         "script": [
             "if ($global) { error \"Global installation is not supported for $cmd\"; break }",
             "$xaml = Get-AppxPackage 'Microsoft.UI.Xaml.2.7' | Sort-Object -Property Version -Descending | Select-Object -First 1",
-            "if ($xaml) { $xamlversion = ($xaml).Version } else { $xamlversion = '0' }",
+            "if ($xaml) { $xamlversion = ($xaml).Version } else { $xamlversion = [version]'0.0.0.0' }",
             "$ProgressPreference = 'SilentlyContinue'",
-            "if ($xamlversion -lt '7.2208.15002.0') { Add-AppxPackage -Path \"$dir\\xaml.appx\" }",
+            "if ($xamlversion -lt [version]'7.2208.15002.0') { Add-AppxPackage -Path \"$dir\\xaml.appx\" }",
             "Add-AppxPackage -Path \"$dir\\devtoys.msixbundle\"",
             "Remove-Item -Path \"$dir\\xaml.appx\", \"$dir\\devtoys.msixbundle\""
         ]


### PR DESCRIPTION
Improves the (un)installer, adds xaml.ui dependency installation

Closes: https://github.com/ScoopInstaller/Nonportable/issues/241

Changes:

- Expands architectures to 64bit and arm64
   - Uses the same msixbundle for all three architectures, because it contains tall three architecture installers (verified via 7-zip)
- forbids global installation, because it is not supported with 'Add-AppxPackage' installation method
   - even 'Add-AppxProvisionedPackage' does not support installing it for all current users, only new ones
- no admin required anymore
- Checks for and if necessary, then it installs dependency 'Microsoft.UI.Xaml.2.7'
- Changes github repository to new location

Tests:
- ✅Install, Uninstall
- ✅Update from v1.0.12.0 to v1.0.13.0
- ✅Tested 64bit fully
- ⚠️Could only test 32-bit with 64-bit dependency instead
- ⚠️Could not test arm64, but installation procedure should be the same

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured application distribution to provide optimized downloads for 32-bit, 64-bit, and ARM64 processors.
  * Reorganized installation and uninstallation workflows with improved architecture-specific handling.
  * Updated version check source.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->