### PR TITLE
vmware-workstation-player-np: Refactor script logic, add notes

### DIFF
--- a/bucket/vmware-workstation-player-np.json
+++ b/bucket/vmware-workstation-player-np.json
@@ -27,7 +27,8 @@
     "installer": {
         "script": [
             "Start-Process -FilePath \"$dir\\setup.exe\" -ArgumentList @('/x') -WindowStyle Hidden -Wait",
-            "Get-ChildItem -Path $env:TEMP -Filter 'VMware*' -Recurse -File | Move-Item -Destination \"$dir\\setup.msi\" -Force",
+            "$installer_files = Get-ChildItem -Path $env:TEMP -Filter 'VMware*' -Recurse -File | Sort-Object -Property LastWriteTime",
+            "$installer_files | Select-Object -Last 1 | Move-Item -Destination \"$dir\\setup.msi\" -Force",
             "$args_list = @('/i', \"$dir\\setup.msi\", '/qn', '/norestart', 'REBOOT=ReallySuppress', 'EULAS_AGREED=1', 'ADDLOCAL=ALL')",
             "Start-Process -FilePath 'msiexec.exe' -ArgumentList $args_list -WindowStyle Hidden -Wait",
             "Remove-Item -Path \"$dir\\setup.exe\" -Force -ErrorAction SilentlyContinue"


### PR DESCRIPTION
### Summary

Refactors the `vmware-workstation-player-np` manifest to improve reliability and updates its documentation to reflect the product's discontinuation in favor of VMware Workstation Pro.

### Related issues or pull requests

- Relates to #529  

### Changes

- **Update** `homepage` URLs to Wayback Machine links, as the original official pages have been removed.
- **Add** comprehensive `notes` informing users about the free availability of VMware Workstation Pro and the temporary nature of the Player's archived download source.
- **Move** installation and uninstallation logic from `pre_install`/`pre_uninstall` into dedicated `installer` and `uninstaller` blocks for better lifecycle management.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket][ vmware-workstation-player-np ≢]
└─> scoop install '.\vmware-workstation-player-np.json'
Installing 'vmware-workstation-player-np' (17.5.0-22583795) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\vmware-workstation-player-np.json'
Loading VMware-player-full-17.5.0-22583795.exe from cache.
Checking hash of VMware-player-full-17.5.0-22583795.exe... OK.
Running pre_install script... Done.
Running installer script... Done.
Linking D:\Software\Scoop\Local\apps\vmware-workstation-player-np\current => D:\Software\Scoop\Local\apps\vmware-workstation-player-np\17.5.0-22583795
'vmware-workstation-player-np' (17.5.0-22583795) was installed successfully!
Notes
-----
As of November 11, 2024, VMware Workstation Pro has been made available free of charge for all users.
For details, please refer to the official announcement:
https://blogs.vmware.com/cloud-foundation/2024/11/11/vmware-fusion-and-workstation-are-now-free-for-all-users/.
Users are strongly encouraged to consider VMware Workstation Pro if they are interested in VMware desktop virtualization products.
However, due to the complexity of its download process, it must be obtained manually from the official website:
https://www.vmware.com/products/desktop-hypervisor/workstation-and-fusion.

Please note that the official website has discontinued the download links for VMware Workstation Player.
As a temporary measure, this manifest uses the Wayback Machine as the download source.
Over time, the compatibility, security, and overall reliability of this application may no longer be guaranteed.
Users should be aware that any issues arising from its use are entirely their own responsibility.
-----

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket][ vmware-workstation-player-np ≢]
└─> scoop uninstall vmware-workstation-player-np -p
Uninstalling 'vmware-workstation-player-np' (17.5.0-22583795).
Running pre_uninstall script... Done.
Running uninstaller script...
Please restart your computer to uninstall vmware-workstation-player-np properly.
Done.
Unlinking D:\Software\Scoop\Local\apps\vmware-workstation-player-np\current
Removing persisted data.
'vmware-workstation-player-np' was uninstalled.
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Refreshed VMware Workstation Player package metadata with an updated homepage and current description.
  * Added informational notes about VMware Workstation availability, approved download sources, and installation caveats.
  * Improved installation and uninstallation flows with explicit privilege checks and MSI-based installer/uninstaller scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->