### PR TITLE
tunnelbear-np: Add version 4.17.0

### DIFF
--- a/bucket/tunnelbear-np.json
+++ b/bucket/tunnelbear-np.json
@@ -1,0 +1,37 @@
+{
+    "version": "4.17.0",
+    "description": "A more secure way to browse the web. TunnelBear encrypts your internet connection to keep your online activity private on any network.",
+    "homepage": "https://www.tunnelbear.com/",
+    "license": {
+        "identifier": "proprietary",
+        "url": "https://www.tunnelbear.com/terms-of-service"
+    },
+    "url": "https://tunnelbear.s3.amazonaws.com/downloads/pc/TunnelBear-Installer.exe",
+    "hash": "f9182c431580d38bc3768b55b64c609c58bfad5aafd08678ee4d083cb0b87217",
+    "pre_install": [
+        "if (!(is_admin)) { error \"Admin rights required to install\"; break }",
+        "if (!($global)) { error \"Only global installation supported\"; break }"
+    ],
+    "installer": {
+        "script": [
+            "Expand-DarkArchive \"$dir/$fname\" \"$dir/extracted\" -Removal",
+            "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\extracted\\AttachedContainer\\TunnelBear.Setup.msi\", '/qn', '/log', \"$dir\\install.log\")",
+            "Remove-Item \"$dir\\extracted\" -Force -Recurse"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if ($cmd -eq 'uninstall') {",
+            "   $id = (Get-ItemProperty -Path 'HKLM://SOFTWARE/WOW6432Node/TunnelBear' -Name Id -ErrorAction SilentlyContinue).Id",
+            "   if ($id -ne $null) { Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$id\", '/qn', '/log', \"$dir\\uninstall.log\") }",
+            "}"
+        ]
+    },
+    "checkver": {
+        "url": "https://prod-api-core.tunnelbear.com/core/web/getVersionHistory?platform=pc",
+        "regex": "Version ([0-9.]+)"
+    },
+    "autoupdate": {
+        "url": "https://tunnelbear.s3.amazonaws.com/downloads/pc/TunnelBear-Installer.exe"
+    }
+}


### PR DESCRIPTION
tunnelbear-np: Add version 4.17.0

- Requires admin, because msi installer only allows admin installation
- Requires global, because msi installer only allows global installation
- Autoupdate does not support older versions
- Vendor changelog version 4.17.0 does not reflect actual installer version 4.17.2.0, so hash changes are likely with these hidden updates
- Tunnelbear likely has an included auto-updater, which should be compatible with the scoop way
    - Could not find a way to deactivate it
    - Could not test it, because no older versions are available
- No arm64 version is available

Closes: https://github.com/ScoopInstaller/Extras/issues/9752
Closes: https://github.com/ScoopInstaller/Nonportable/issues/102
Relates: https://github.com/TheRandomLabs/scoop-nonportable/issues/369

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TunnelBear application support to the package manager ecosystem with comprehensive installation, uninstallation, and lifecycle management capabilities. Features include automatic version detection and checking, seamless update support, and pre-deployment environment validation to ensure successful installation across diverse system configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->