### PR TITLE
8gadgetpack-np: Update to version 39.0, fix checkver & autoupdate

### DIFF
--- a/bucket/8gadgetpack-np.json
+++ b/bucket/8gadgetpack-np.json
@@ -1,21 +1,21 @@
 {
-    "version": "37.0",
+    "version": "39.0",
     "description": "Gadgets for Windows.",
-    "homepage": "https://8gadgetpack.net/",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://8gadgetpack.net/#FAQ"
-    },
-    "url": "https://8gadgetpack.net/dl_370/8GadgetPackSetup.msi#/setup.msi_",
-    "hash": "821e33cf757bd01bec6703796c01726e6674b8de3bc1e7ea834318039e46909e",
+    "homepage": "https://gadgetpack.net",
+    "license": "Freeware",
+    "url": "https://gadgetpack.net/dl_390/GadgetPackSetup.msi#/setup.msi_",
+    "hash": "1a89f9c908bf4313a813b63a701c95dcf53538a66ce2ededc5aa0635da1a7338",
     "installer": {
         "script": "Start-Process msiexec -ArgumentList @('/i', \"`\"$dir\\setup.msi_`\"\", '/qn') -Wait -Verb RunAs | Out-Null"
     },
     "uninstaller": {
         "script": "Start-Process msiexec -ArgumentList @('/x', \"`\"$dir\\setup.msi_`\"\", '/qn') -Wait -Verb RunAs | Out-Null"
     },
-    "checkver": "Version ([\\d.]+) released",
+    "checkver": {
+        "url": "https://gadgetpack.net/changelog.html",
+        "regex": "Version\\s*([\\d.]+)"
+    },
     "autoupdate": {
-        "url": "https://8gadgetpack.net/dl_$cleanVersion/8GadgetPackSetup.msi#/setup.msi_"
+        "url": "https://gadgetpack.net/dl_$cleanVersion/GadgetPackSetup.msi#/setup.msi_"
     }
 }


### PR DESCRIPTION
### Changes

- Update homepage field
- Update version to **39.0**
- Fix checkver & autoupdate 

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\8gadgetpack-np.json' -f
8gadgetpack-np: 39.0 (scoop version is 39.0)
Forcing autoupdate!
Autoupdating 8gadgetpack-np
DEBUG[1769605809] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1769605809] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1769605809] $substitutions.$dotVersion                    39.0
DEBUG[1769605809] $substitutions.$basenameNoExt                 GadgetPackSetup
DEBUG[1769605809] $substitutions.$urlNoExt                      https://gadgetpack.net/dl_390/GadgetPackSetup
DEBUG[1769605809] $substitutions.$dashVersion                   39-0
DEBUG[1769605809] $substitutions.$basename                      GadgetPackSetup.msi
DEBUG[1769605809] $substitutions.$match1                        39.0
DEBUG[1769605809] $substitutions.$cleanVersion                  390
DEBUG[1769605809] $substitutions.$majorVersion                  39
DEBUG[1769605809] $substitutions.$buildVersion
DEBUG[1769605809] $substitutions.$preReleaseVersion             39.0
DEBUG[1769605809] $substitutions.$matchHead                     39.0
DEBUG[1769605809] $substitutions.$url                           https://gadgetpack.net/dl_390/GadgetPackSetup.msi
DEBUG[1769605809] $substitutions.$version                       39.0
DEBUG[1769605809] $substitutions.$baseurl                       https://gadgetpack.net/dl_390
DEBUG[1769605809] $substitutions.$minorVersion                  0
DEBUG[1769605809] $substitutions.$patchVersion
DEBUG[1769605809] $substitutions.$underscoreVersion             39_0
DEBUG[1769605809] $substitutions.$matchTail
DEBUG[1769605809] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Downloading GadgetPackSetup.msi to compute hashes!
Loading GadgetPackSetup.msi from cache
Computed hash: 1a89f9c908bf4313a813b63a701c95dcf53538a66ce2ededc5aa0635da1a7338
Writing updated 8gadgetpack-np manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop download 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\8gadgetpack-np.json'
INFO  Downloading '8gadgetpack-np' [64bit]
Loading GadgetPackSetup.msi from cache.
Checking hash of GadgetPackSetup.msi... OK.
'8gadgetpack-np' (39.0) was downloaded successfully!

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Version upgraded to 39.0
  * Homepage and package distribution domain migrated to new primary location
  * Installer package updated with new filename and modified download location
  * License field representation changed from structured format to simplified string
  * Package configuration updated with new version tracking approach

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->