### PR TITLE
virtualbox(-with-extension-pack)-np@7.2.6.172322: Fix installer script

### DIFF
--- a/bucket/virtualbox-np.json
+++ b/bucket/virtualbox-np.json
@@ -18,13 +18,14 @@
     ],
     "installer": {
         "script": [
-            "$setup = Get-ChildItem \"$dir\\VirtualBox*_amd64.msi\" | Select-Object -First 1",
+            "$setup = Get-ChildItem -Path \"$dir\" -Filter 'VirtualBox-*.msi' | Select-Object -First 1",
             "if (-not $setup) { error \"MSI not found under $dir\"; break }",
             "$args = @('/i', \"$($setup.FullName)\", '/qn', '/norestart', '/log', \"$dir\\install-log.txt\", 'VBOX_INSTALLDESKTOPSHORTCUT=0', 'VBOX_INSTALLQUICKLAUNCHSHORTCUT=0', 'VBOX_START=0', 'VBOX_INSTALLSTARTMENUENTRIES=0')",
             "if (!$global) { $args += 'ALLUSERS=2', \"INSTALLDIR=`\"$dir`\"\" }",
             "if ($global) { $args += 'ALLUSERS=1' }",
             "$succ = Invoke-ExternalCommand msiexec -ArgumentList $args",
-            "Remove-Item -Path @(\"$dir\\VirtualBox-*64.msi\", \"$dir\\common.cab\")",
+            "Get-ChildItem -Path \"$dir\" -Filter 'VirtualBox-*.msi' | Remove-Item",
+            "Get-ChildItem -Path \"$dir\" -Filter 'common.cab' | Remove-Item",
             "if (-not $succ) {",
             "   Select-String -Path \"$dir\\install-log.txt\" -Pattern 'MSI \\(.*' | ForEach-Object { warn \"from log:`n    $_\" }",
             "   error \"Failed ($succ) to install `\"$($setup.FullName)`\".`nLog file: `\"$dir\\install-log.txt`\"\"",

--- a/bucket/virtualbox-with-extension-pack-np.json
+++ b/bucket/virtualbox-with-extension-pack-np.json
@@ -32,13 +32,14 @@
     ],
     "installer": {
         "script": [
-            "$setup = Get-ChildItem \"$dir\\VirtualBox*_amd64.msi\" | Select-Object -First 1",
+            "$setup = Get-ChildItem -Path \"$dir\" -Filter 'VirtualBox-*.msi' | Select-Object -First 1",
             "if (-not $setup) { error \"MSI not found under $dir\"; break }",
             "$args = @('/i', \"$($setup.FullName)\", '/qn', '/norestart', '/log', \"$dir\\install-log.txt\", 'VBOX_INSTALLDESKTOPSHORTCUT=0', 'VBOX_INSTALLQUICKLAUNCHSHORTCUT=0', 'VBOX_START=0', 'VBOX_INSTALLSTARTMENUENTRIES=0')",
             "if (!$global) { $args += 'ALLUSERS=2', \"INSTALLDIR=`\"$dir`\"\" }",
             "if ($global) { $args += 'ALLUSERS=1' }",
             "$succ = Invoke-ExternalCommand msiexec -ArgumentList $args",
-            "Remove-Item -Path @(\"$dir\\VirtualBox-*64.msi\", \"$dir\\common.cab\")",
+            "Get-ChildItem -Path \"$dir\" -Filter 'VirtualBox-*.msi' | Remove-Item",
+            "Get-ChildItem -Path \"$dir\" -Filter 'common.cab' | Remove-Item",
             "if (-not $succ) {",
             "   Select-String -Path \"$dir\\install-log.txt\" -Pattern 'MSI \\(.*' | ForEach-Object { warn \"from log:`n    $_\" }",
             "   error \"Failed ($succ) to install `\"$($setup.FullName)`\".`nLog file: `\"$dir\\install-log.txt`\"\"",


### PR DESCRIPTION
Fixes installer for version 7.2.6, while being backward compatible.

Changes:
- Fixes both `virtualbox-np` and `virtualbox-with-extension-pack-np`
- Installers v7.2.4 and earlier contained `VirtualBox-*_amd64.msi` and `VritualBox-*_arm64.msi` files
    - Installer v7.2.6 does not contain the arm file anymore and removes the architecture from the filename
    - New msi selector is compatible with both old and new naming scheme
- Installer v7.2.6 does not contain `common.cab` anymore

Closes: https://github.com/ScoopInstaller/Nonportable/issues/545

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VirtualBox installer scripts with improved file discovery and cleanup procedures for enhanced installation reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->