### PR TITLE
bluestacks-np: Update to version 5.22.150.1014, fix checkver & autoupdate

### DIFF
--- a/bucket/bluestacks-np.json
+++ b/bucket/bluestacks-np.json
@@ -1,19 +1,15 @@
 {
-    "version": "5.21.150.1026",
+    "version": "5.22.150.1014",
     "description": "Android emulator",
-    "homepage": "https://www.bluestacks.com/",
+    "homepage": "https://www.bluestacks.com/bluestacks-5.html",
     "license": {
         "identifier": "Freeware",
-        "url": "https://www.bluestacks.com/tw/terms-and-privacy.html"
+        "url": "https://www.bluestacks.com/terms-and-privacy.html#terms"
     },
     "architecture": {
         "64bit": {
-            "url": "https://cdn3.bluestacks.com/downloads/windows/nxt/5.21.150.1026/d38633a7cfb05064017b34130c3da255/FullInstaller/x64/BlueStacksFullInstaller_5.21.150.1026_amd64_native.exe#/setup.exe",
-            "hash": "bd9aabda26cc1e26d7308effe76503cd229c334be36bd359bc85290789ef8c64"
-        },
-        "32bit": {
-            "url": "https://cdn3.bluestacks.com/downloads/windows/nxt/5.21.150.1026/d38633a7cfb05064017b34130c3da255/FullInstaller/x86/BlueStacksFullInstaller_5.21.150.1026_x86_native.exe#/setup.exe",
-            "hash": "79bc97e854e11cde0907092a72f2be68fec385c37b21e56166eb7a6892aefd23"
+            "url": "https://ak-build.bluestacks.com/public/app-player/windows/nxt/5.22.150.1014/c6b85b9680fe708a143d721bdc7dd4e3/FullInstaller/x64/BlueStacksFullInstaller_5.22.150.1014_amd64_native.exe#/setup.exe",
+            "hash": "5ad80b2b1d63095d593d81f364247cbd14b2b1acd266218b62303388375e5da7"
         }
     },
     "installer": {
@@ -35,17 +31,33 @@
         ]
     },
     "checkver": {
-        "url": "https://webcache.googleusercontent.com/search?q=cache:https://support.bluestacks.com/hc/en-us/articles/4402611273485-BlueStacks-5-offline-installer",
-        "regex": "windows/nxt/([\\d.]+)/(?<sha>[0-9a-f]+)/"
+        "script": [
+            "$first_letter, $publisher, $package = 'b', 'BlueStack', 'BlueStacks'",
+            "$manifests_root = 'https://api.github.com/repositories/197275551/contents/manifests'",
+            "$package_url = '{0}/{1}/{2}/{3}' -f $manifests_root, $first_letter, $publisher, $package",
+            "$response = Invoke-RestMethod -Uri $package_url -Method Get -ErrorAction Stop",
+            "$path_segments = $response | Where-Object { $_.type -eq 'dir' } |",
+            "        Sort-Object -Property { [version]$_.name } -Descending | ForEach-Object -MemberName name",
+            "foreach ($path_segment in $path_segments) {",
+            "    $manifest_url = '{0}/{1}/{2}/{3}/{4}/{2}.{3}.installer.yaml' -f $manifests_root, $first_letter, $publisher, $package, $path_segment",
+            "    $manifest_info = Invoke-RestMethod -Uri $manifest_url -Headers @{ 'Accept' = 'application/vnd.github.v3.raw' } -ErrorAction Stop",
+            "    if ($null -ne $manifest_info -and $manifest_info -match 'nxt/(?<version>[\\d.]+)/(?<token>[^/]+)') {",
+            "        Write-Output \"$($Matches['version']), $($Matches['token'])\"",
+            "        break",
+            "    }",
+            "}"
+        ],
+        "regex": "([\\d.]+), (?<token>.+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn3.bluestacks.com/downloads/windows/nxt/$version/$matchSha/FullInstaller/x64/BlueStacksFullInstaller_$version_amd64_native.exe#/setup.exe"
-            },
-            "32bit": {
-                "url": "https://cdn3.bluestacks.com/downloads/windows/nxt/$version/$matchSha/FullInstaller/x86/BlueStacksFullInstaller_$version_x86_native.exe#/setup.exe"
+                "url": "https://ak-build.bluestacks.com/public/app-player/windows/nxt/$version/$matchToken/FullInstaller/x64/BlueStacksFullInstaller_$version_amd64_native.exe#/setup.exe"
             }
+        },
+        "hash": {
+            "url": "https://raw.githubusercontent.com/microsoft/winget-pkgs/HEAD/manifests/b/BlueStack/BlueStacks/$version/BlueStack.BlueStacks.installer.yaml",
+            "regex": "(?s)$basename.+?$sha256"
         }
     }
 }


### PR DESCRIPTION
### Summary

Updates `bluestacks-np` to version **5.22.150.1014** and implements a robust version tracking system using the WinGet package repository.

### Related issues or pull requests

- Relates to #548  

### Changes

- **Update** version to **5.22.150.1014**.
- **Refine** `homepage` and `license` URLs to point to more specific and accurate documentation pages.
- **Remove** `32bit` architecture support.
- **Refactor** `checkver` from a fragile Google Web Cache scraping method to a PowerShell script that queries the `microsoft/winget-pkgs` GitHub repository to extract the latest version and download token.
- **Update** `autoupdate` to use the official WinGet manifest YAML as the source of truth for hashes.

### Notes

- Reason for removing `32-bit` architecture support

  ```powershell
  ┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
  └─> .\checkver.ps1 -App 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\bluestacks-np.json' -f
  bluestacks-np: 5.22.150.1014 (scoop version is 5.22.150.1014)
  Forcing autoupdate!
  Autoupdating bluestacks-np
  DEBUG[1769866037] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
  DEBUG[1769866037] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
  DEBUG[1769866037] $substitutions.$majorVersion                  5
  DEBUG[1769866037] $substitutions.$dotVersion                    5.22.150.1014
  DEBUG[1769866037] $substitutions.$patchVersion                  150
  DEBUG[1769866037] $substitutions.$dashVersion                   5-22-150-1014
  DEBUG[1769866037] $substitutions.$url                           https://ak-build.bluestacks.com/public/app-player/windows/nxt/5.22.150.1014/c6b85b9680fe708a143d721bdc7dd4e3/FullInstaller/x…
  DEBUG[1769866037] $substitutions.$minorVersion                  22
  DEBUG[1769866037] $substitutions.$baseurl                       https://ak-build.bluestacks.com/public/app-player/windows/nxt/5.22.150.1014/c6b85b9680fe708a143d721bdc7dd4e3/FullInstaller/x…
  DEBUG[1769866037] $substitutions.$matchHead                     5.22.150
  DEBUG[1769866037] $substitutions.$match1                        5.22.150.1014
  DEBUG[1769866037] $substitutions.$buildVersion                  1014
  DEBUG[1769866037] $substitutions.$matchToken                    c6b85b9680fe708a143d721bdc7dd4e3
  DEBUG[1769866037] $substitutions.$preReleaseVersion             5.22.150.1014
  DEBUG[1769866037] $substitutions.$version                       5.22.150.1014
  DEBUG[1769866037] $substitutions.$cleanVersion                  5221501014
  DEBUG[1769866037] $substitutions.$matchTail                     .1014
  DEBUG[1769866037] $substitutions.$urlNoExt                      https://ak-build.bluestacks.com/public/app-player/windows/nxt/5.22.150.1014/c6b85b9680fe708a143d721bdc7dd4e3/FullInstaller/x…
  DEBUG[1769866037] $substitutions.$basenameNoExt                 BlueStacksFullInstaller_5.22.150.1014_x86_native
  DEBUG[1769866037] $substitutions.$underscoreVersion             5_22_150_1014
  DEBUG[1769866037] $substitutions.$basename                      BlueStacksFullInstaller_5.22.150.1014_x86_native.exe
  DEBUG[1769866037] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
  Downloading BlueStacksFullInstaller_5.22.150.1014_x86_native.exe to compute hashes!
  The remote server returned an error: (404) Not Found.
  URL https://ak-build.bluestacks.com/public/app-player/windows/nxt/5.22.150.1014/c6b85b9680fe708a143d721bdc7dd4e3/FullInstaller/x86/BlueStacksFullInstaller_5.22.150.1014_x86_native.exe#/setup.exe is not valid
  ERROR Could not update bluestacks-np, hash for BlueStacksFullInstaller_5.22.150.1014_x86_native.exe failed!
  ```

- Currently, it is not possible to check for updates via Google's cached page.

> ~The problem is, the page cannot be loaded with `Invoke-WebRequest` or `Invoke-RestMethod` (error 403: Forbidden), probably related to some checks involving JavaScript.~
> 
> ~This happens even if I use the **user-agent** copied from Chrome. (`'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/604.5.6 (KHTML, like Gecko) Version/11.0.3 Safari/604.5.6'`)~
> 
> I found that we can circumvent the problem by using [Google's cached page](https://webcache.googleusercontent.com/search?q=cache:https://support.bluestacks.com/hc/en-us/articles/4402611273485-BlueStacks-5-offline-installer). I think lagging a little bit (in terms of page update) is fine because **BlueStacks** does not update that often.

- https://github.com/ScoopInstaller/Nonportable/issues/46#issuecomment-1207204620

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\bluestacks-np.json' -f
bluestacks-np: 5.22.150.1014 (scoop version is 5.22.150.1014)
Forcing autoupdate!
Autoupdating bluestacks-np
DEBUG[1769867357] [$updatedProperties] = [hash url] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1769867357] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1769867357] $substitutions.$majorVersion                  5
DEBUG[1769867357] $substitutions.$dotVersion                    5.22.150.1014
DEBUG[1769867357] $substitutions.$patchVersion                  150
DEBUG[1769867357] $substitutions.$dashVersion                   5-22-150-1014
DEBUG[1769867357] $substitutions.$url                           https://ak-build.bluestacks.com/public/app-player/windows/nxt/5.22.150.1014/c6b85b9680fe708a143d721bdc7dd4e3/FullInstaller/x…
DEBUG[1769867357] $substitutions.$minorVersion                  22
DEBUG[1769867357] $substitutions.$baseurl                       https://ak-build.bluestacks.com/public/app-player/windows/nxt/5.22.150.1014/c6b85b9680fe708a143d721bdc7dd4e3/FullInstaller/x…
DEBUG[1769867357] $substitutions.$matchHead                     5.22.150
DEBUG[1769867357] $substitutions.$match1                        5.22.150.1014
DEBUG[1769867357] $substitutions.$buildVersion                  1014
DEBUG[1769867357] $substitutions.$matchToken                    c6b85b9680fe708a143d721bdc7dd4e3
DEBUG[1769867357] $substitutions.$preReleaseVersion             5.22.150.1014
DEBUG[1769867357] $substitutions.$version                       5.22.150.1014
DEBUG[1769867357] $substitutions.$cleanVersion                  5221501014
DEBUG[1769867357] $substitutions.$matchTail                     .1014
DEBUG[1769867357] $substitutions.$urlNoExt                      https://ak-build.bluestacks.com/public/app-player/windows/nxt/5.22.150.1014/c6b85b9680fe708a143d721bdc7dd4e3/FullInstaller/x…
DEBUG[1769867357] $substitutions.$basenameNoExt                 BlueStacksFullInstaller_5.22.150.1014_amd64_native
DEBUG[1769867357] $substitutions.$underscoreVersion             5_22_150_1014
DEBUG[1769867357] $substitutions.$basename                      BlueStacksFullInstaller_5.22.150.1014_amd64_native.exe
DEBUG[1769867357] $hashfile_url = https://raw.githubusercontent.com/microsoft/winget-pkgs/HEAD/manifests/b/BlueStack/BlueStacks/5.22.150.1014/BlueStack.BlueStacks.installer.yaml -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for BlueStacksFullInstaller_5.22.150.1014_amd64_native.exe in https://raw.githubusercontent.com/microsoft/winget-pkgs/HEAD/manifests/b/BlueStack/BlueStacks/5.22.150.1014/BlueStack.BlueStacks.installer.yaml
DEBUG[1769867357] $regex = (?s)BlueStacksFullInstaller_5\.22\.150\.1014_amd64_native\.exe.+?([a-fA-F0-9]{64}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:80:9
Found: 5ad80b2b1d63095d593d81f364247cbd14b2b1acd266218b62303388375e5da7 using Extract Mode
Writing updated bluestacks-np manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop download 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\bluestacks-np.json'
INFO  Downloading 'bluestacks-np' [64bit]
Starting download with aria2...
Download: Download Results:
Download: gid   |stat|avg speed  |  %|path/URI
Download: ======+====+===========+===+===================================================
Download: de0120|OK  |    41MiB/s|100|D:/Software/Scoop/Local/cache/bluestacks-np#5.22.150.1014#51b3e6e.exe
Download: Status Legend:
Download: (OK):download completed.
Checking hash of BlueStacksFullInstaller_5.22.150.1014_amd64_native.exe... OK.
'bluestacks-np' (5.22.150.1014) was downloaded successfully!

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Uninstaller functionality is now available to help users cleanly remove previous versions and installations from their systems.

* **Chores**
  * Version updated to 5.22.150.1014 with enhanced deployment and automated update infrastructure.
  * 32-bit system support has been completely discontinued; 64-bit systems are now required.
  * Updated license terms and homepage references to align with current standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->