### PR TITLE
ditto-np: Update to version 3.25.113.0, fix checkver & autoupdate

### DIFF
--- a/bucket/ditto-np.json
+++ b/bucket/ditto-np.json
@@ -1,16 +1,15 @@
 {
-    "version": "3.24.246.0",
-    "description": "Windows clipboard extension.",
-    "homepage": "http://ditto-cp.sourceforge.net/",
-    "license": "GPL-3.0-only",
+    "version": "3.25.113.0",
+    "description": "A Windows clipboard enhancement utility that extends the standard clipboard by storing copied items for later reuse, with support for multiple data types including text, images, HTML, and custom formats.",
+    "homepage": "https://sabrogden.github.io/Ditto/",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/sabrogden/Ditto/blob/HEAD/LICENSE"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/3.24.246.0/DittoSetup_64bit_3_24_246_0.exe#/setup.exe",
-            "hash": "sha1:c4830977e33055021e02aea4a26a3decd12c0f28"
-        },
-        "32bit": {
-            "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/3.24.246.0/DittoSetup_3_24_246_0.exe#/setup.exe",
-            "hash": "sha1:05efb206c0741754b600403fcf87b469f8124167"
+            "url": "https://github.com/sabrogden/Ditto/releases/download/3.25.113.0/DittoSetup_3_25_113_0.exe#/setup.exe",
+            "hash": "fc354f1e9b9d2984099d4da93b4c569866dfe9bf1f590c1313e85e07f41224d3"
         }
     },
     "installer": {
@@ -35,14 +34,13 @@
             "Ditto"
         ]
     ],
-    "checkver": "var versionDots=\"([\\d.]+)\"",
+    "checkver": {
+        "github": "https://github.com/sabrogden/Ditto"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/$version/DittoSetup_64bit_$underscoreVersion.exe#/setup.exe"
-            },
-            "32bit": {
-                "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/$version/DittoSetup_$underscoreVersion.exe#/setup.exe"
+                "url": "https://github.com/sabrogden/Ditto/releases/download/$version/DittoSetup_$underscoreVersion.exe#/setup.exe"
             }
         }
     }


### PR DESCRIPTION
### Summary

Updates `ditto-np` to version **3.25.113.0**, migrates the source repository to GitHub, and improves manifest metadata.

### Related issues or pull requests

- Relates to #548 

### Changes

- **Update** version to **3.25.113.0**.
- **Migrate** `homepage`, `url`, `checkver`, and `autoupdate` from SourceForge to GitHub for better reliability.
- **Refine** `license` field with the correct SPDX identifier (`GPL-3.0-or-later`) and a direct link to the license file.
- **Enhance** `description` to provide a more comprehensive overview of the utility's features.
- **Remove** `32bit` architecture support to focus on modern systems and reduce maintenance overhead.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\ditto-np.json' -f
ditto-np: 3.25.113.0 (scoop version is 3.24.246.0) autoupdate available
Forcing autoupdate!
Autoupdating ditto-np
DEBUG[1769869165] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1769869165] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1769869165] $substitutions.$dotVersion                    3.25.113.0
DEBUG[1769869165] $substitutions.$patchVersion                  113
DEBUG[1769869165] $substitutions.$dashVersion                   3-25-113-0
DEBUG[1769869165] $substitutions.$url                           https://github.com/sabrogden/Ditto/releases/download/3.25.113.0/DittoSetup_3_25_113_0.exe
DEBUG[1769869165] $substitutions.$version                       3.25.113.0
DEBUG[1769869165] $substitutions.$baseurl                       https://github.com/sabrogden/Ditto/releases/download/3.25.113.0
DEBUG[1769869165] $substitutions.$matchHead                     3.25.113
DEBUG[1769869165] $substitutions.$buildVersion                  0
DEBUG[1769869165] $substitutions.$majorVersion                  3
DEBUG[1769869165] $substitutions.$preReleaseVersion             3.25.113.0
DEBUG[1769869165] $substitutions.$minorVersion                  25
DEBUG[1769869165] $substitutions.$match1                        3.25.113.0
DEBUG[1769869165] $substitutions.$cleanVersion                  3251130
DEBUG[1769869165] $substitutions.$matchTail                     .0
DEBUG[1769869165] $substitutions.$urlNoExt                      https://github.com/sabrogden/Ditto/releases/download/3.25.113.0/DittoSetup_3_25_113_0
DEBUG[1769869165] $substitutions.$basenameNoExt                 DittoSetup_3_25_113_0
DEBUG[1769869165] $substitutions.$underscoreVersion             3_25_113_0
DEBUG[1769869165] $substitutions.$basename                      DittoSetup_3_25_113_0.exe
DEBUG[1769869165] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1769869166] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/sabrogden/Ditto/releases/download/3.25.113.0/DittoSetup_3_25_113_0.exe')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: fc354f1e9b9d2984099d4da93b4c569866dfe9bf1f590c1313e85e07f41224d3 using Github Mode
Writing updated ditto-np manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop download 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\ditto-np.json'
INFO  Downloading 'ditto-np' [64bit]
Starting download with aria2...
Download: Download Results:
Download: gid   |stat|avg speed  |  %|path/URI
Download: ======+====+===========+===+===================================================
Download: 6fc56a|OK  |    15MiB/s|100|D:/Software/Scoop/Local/cache/ditto-np#3.25.113.0#c0802ec.exe
Download: Status Legend:
Download: (OK):download completed.
Checking hash of DittoSetup_3_25_113_0.exe... OK.
'ditto-np' (3.25.113.0) was downloaded successfully!

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated to version 3.25.113.0
  * Migrated downloads from SourceForge to GitHub releases
  * Removed 32-bit version support; 64-bit only
  * Updated project homepage and license information

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->