### PR TITLE
nodejs-lts-np: Update to version 24.13.0, drop 32bit support

### DIFF
--- a/bucket/nodejs-lts-np.json
+++ b/bucket/nodejs-lts-np.json
@@ -1,19 +1,19 @@
 {
-    "version": "22.21.0",
+    "version": "24.13.0",
     "description": "JavaScript runtime environment.",
     "homepage": "https://nodejs.org",
     "license": "MIT",
     "notes": "npm global prefix set to: $env:APPDATA\\npm",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v22.21.0/node-v22.21.0-win-x64.7z",
-            "hash": "31a82a950fd2524651f0409307afe3276ae68a13a131e8b72945a3931109c8c3",
-            "extract_dir": "node-v22.21.0-win-x64"
+            "url": "https://nodejs.org/dist/v24.13.0/node-v24.13.0-win-x64.7z",
+            "hash": "04d3619e21c07a84043accbacc73256431c6adbea65d4c026c6eb22ff6fd453a",
+            "extract_dir": "node-v24.13.0-win-x64"
         },
-        "32bit": {
-            "url": "https://nodejs.org/dist/v22.21.0/node-v22.21.0-win-x86.7z",
-            "hash": "d2767e24741f915477002d6325dda40f7554ce9e5176c8d2e824dc127d273725",
-            "extract_dir": "node-v22.21.0-win-x86"
+        "arm64": {
+            "url": "https://nodejs.org/dist/v24.13.0/node-v24.13.0-win-arm64.7z",
+            "hash": "724fcf1a20ea345cc38fb970044a6f1617a1dc47e477ee5a92fe8b243b95700a",
+            "extract_dir": "node-v24.13.0-win-arm64"
         }
     },
     "installer": {
@@ -31,8 +31,8 @@
     ],
     "checkver": {
         "url": "https://nodejs.org/dist/index.json",
-        "jsonpath": "$..[?(@.lts != false)].version",
-        "regex": "v([\\d\\.]+).*"
+        "jsonpath": "$[?(@.lts != false)].version",
+        "regex": "v([\\d\\.]+)"
     },
     "autoupdate": {
         "architecture": {
@@ -40,9 +40,9 @@
                 "url": "https://nodejs.org/dist/v$version/node-v$version-win-x64.7z",
                 "extract_dir": "node-v$version-win-x64"
             },
-            "32bit": {
-                "url": "https://nodejs.org/dist/v$version/node-v$version-win-x86.7z",
-                "extract_dir": "node-v$version-win-x86"
+            "arm64": {
+                "url": "https://nodejs.org/dist/v$version/node-v$version-win-arm64.7z",
+                "extract_dir": "node-v$version-win-arm64"
             }
         },
         "hash": {


### PR DESCRIPTION

### Summary

Updates `nodejs-lts-np` to version **24.13.0** and restructures the manifest to support **ARM64** while deprecating **32-bit**.

### Related issues or pull requests

- Relates to #548  

### Changes

- **Update** version to **24.13.0**.
- **Add** `arm64` architecture support for Windows on ARM devices.
- **Remove** `32bit` architecture as it is increasingly less relevant for modern Node.js LTS deployments.
- **Simplify** `checkver` JSONPath and regex for more direct property access and cleaner matching.
- **Synchronize** `autoupdate` logic to reflect the new architecture layout (64bit and arm64).

### Notes

- Upstream discontinued support for 32-bit Windows systems in version 23.0.0.
  - See: https://github.com/nodejs/node/releases/tag/v23.0.0

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\nodejs-lts-np.json' -f
nodejs-lts-np: 24.13.0 (scoop version is 22.21.0) autoupdate available
Forcing autoupdate!
Autoupdating nodejs-lts-np
DEBUG[1769871515] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1769871515] $substitutions.$dotVersion                    24.13.0
DEBUG[1769871515] $substitutions.$patchVersion                  0
DEBUG[1769871515] $substitutions.$dashVersion                   24-13-0
DEBUG[1769871515] $substitutions.$url                           https://nodejs.org/dist/v24.13.0/node-v24.13.0-win-arm64.7z
DEBUG[1769871515] $substitutions.$version                       24.13.0
DEBUG[1769871515] $substitutions.$baseurl                       https://nodejs.org/dist/v24.13.0
DEBUG[1769871515] $substitutions.$matchHead                     24.13.0
DEBUG[1769871515] $substitutions.$buildVersion
DEBUG[1769871515] $substitutions.$majorVersion                  24
DEBUG[1769871515] $substitutions.$preReleaseVersion             24.13.0
DEBUG[1769871515] $substitutions.$minorVersion                  13
DEBUG[1769871515] $substitutions.$match1                        24.13.0
DEBUG[1769871515] $substitutions.$cleanVersion                  24130
DEBUG[1769871515] $substitutions.$matchTail
DEBUG[1769871515] $substitutions.$urlNoExt                      https://nodejs.org/dist/v24.13.0/node-v24.13.0-win-arm64
DEBUG[1769871515] $substitutions.$basenameNoExt                 node-v24.13.0-win-arm64
DEBUG[1769871515] $substitutions.$underscoreVersion             24_13_0
DEBUG[1769871515] $substitutions.$basename                      node-v24.13.0-win-arm64.7z
DEBUG[1769871515] $hashfile_url = https://nodejs.org/dist/v24.13.0/SHASUMS256.txt.asc -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for node-v24.13.0-win-arm64.7z in https://nodejs.org/dist/v24.13.0/SHASUMS256.txt.asc
DEBUG[1769871516] $filenameRegex = ([a-fA-F0-9]{32,128})[\x20\t]+.*node-v24\.13\.0-win-arm64\.7z(?:\s|$)|node-v24\.13\.0-win-arm64\.7z[\x20\t]+.*?([a-fA-F0-9]{32,128}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:101:13
Found: 724fcf1a20ea345cc38fb970044a6f1617a1dc47e477ee5a92fe8b243b95700a using Extract Mode
Writing updated nodejs-lts-np manifest
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js LTS to version 24.13.0.

* **New Features**
  * Added support for ARM64 architecture.

* **Removals**
  * Removed 32-bit architecture support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->