### PR TITLE
virtualbox(-with-extension-pack)-np: Update to version 7.2.6a-172322, fix checkver & autoupdate

### DIFF
--- a/bucket/virtualbox-np.json
+++ b/bucket/virtualbox-np.json
@@ -60,7 +60,7 @@
     },
     "checkver": {
         "url": "https://www.virtualbox.org/wiki/Downloads",
-        "regex": "VirtualBox-([0-9a-z.-]+)-Win.exe"
+        "regex": "VirtualBox-([\\w.-]+)-Win.exe"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/virtualbox-with-extension-pack-np.json
+++ b/bucket/virtualbox-with-extension-pack-np.json
@@ -84,7 +84,7 @@
     },
     "checkver": {
         "url": "https://www.virtualbox.org/wiki/Downloads",
-        "regex": "VirtualBox-([0-9a-z.-]+)-Win.exe"
+        "regex": "VirtualBox-([\\w.-]+)-Win.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
### Summary

Update to version 7.2.6a-172322, fix checkver & autoupdate

### Related

- Relates to #548 

### Changes:
- VirtualBox sometimes releases updates with letters, like in this case: 7.2.6a
    - Expanded checkver to make it more robust and future-proof
- Incorporated simpler autoupdate from https://github.com/ScoopInstaller/Nonportable/pull/536#issuecomment-3824928608. Thank you SorYoshino 👍
- Updates to new version 7.2.6a-172322

### Tests
- ✅ checkver.ps1
- ✅ checkver.ps1 -f
- ⚠️ Update with local json test failed:
    - I installed the previous version `7.2.6.172322` through a local manifest json file and then updated that file to the following version strings:
        - ❌ Not detected as newer: `7.2.6a-172322`
        - ❌ Not detected as newer: `7.2.6a.172322`
        - ❌ Not detected as newer: `7.2.6-a.172322`
        - ✅ Detected as newer: `7.2.6.172322-a`
        - ❌ Not detected as newer: `7.2.6-a+172322`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated VirtualBox version from 7.2.6.172322 to 7.2.6a-172322.
  * Updated installer and extension pack URLs and SHA256 checksum to match the new version format.
  * Simplified version-detection patterns and autoupdate URL templates for more straightforward update checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->