### PR TITLE
rom-properties-np@2.7.1: move vcredist from depends to suggest

### DIFF
--- a/bucket/rom-properties-np.json
+++ b/bucket/rom-properties-np.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/GerbilSoft/rom-properties",
     "license": "GPL-2.0-or-later",
     "suggest": {
-        "vcredist": "extras/vcredist2022"
+        "Microsoft Visual C++ Redistributable for Visual Studio 2015-2022": "extras/vcredist2022"
     },
     "url": "https://github.com/GerbilSoft/rom-properties/releases/download/v2.7.1/SetupRomProperties-2.7.1.exe",
     "hash": "17d9e19d3d9d5201c70ab0e1a6b325be7c09e7dfc31b322fc69b73695523a3cc",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
`extras/vcredist2022` isn't meant to be kept installed *in Scoop*, so making it a "hard" dependency is pointless.
Also simplified license specification (url isn't needed because it's an SPDX license)
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
Relates to #XXXX
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified the license declaration to a shorter format.
  * Added a suggestion mapping for Microsoft Visual C++ Redistributable (2015–2022) to point to the vcredist2022 package.
  * Removed the automatic dependency on the vcredist2022 package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->