### PR TITLE
(chore): Set SCOOP_BRANCH to develop in workflows

### DIFF
--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -14,4 +14,5 @@ jobs:
       uses: ScoopInstaller/GithubActions@main
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCOOP_BRANCH: develop
         SKIP_UPDATED: '1'

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -13,3 +13,4 @@ jobs:
       if: startsWith(github.event.comment.body, '/verify')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCOOP_BRANCH: develop

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -13,3 +13,4 @@ jobs:
       if: github.event.action == 'opened' || (github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'verify'))
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCOOP_BRANCH: develop

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,3 +12,4 @@ jobs:
       uses: ScoopInstaller/GithubActions@main
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCOOP_BRANCH: develop


### PR DESCRIPTION
### Summary

Set `SCOOP_BRANCH` to `develop` in workflows.

### Related issues or pull requests

- Relates to https://github.com/ScoopInstaller/Extras/pull/17065 
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated GitHub Actions workflow configurations to standardize environment settings across multiple automation pipelines used for build validation, pull request processing, and issue management. Configuration enhancements ensure consistent behavior across continuous integration and deployment workflows, improving overall pipeline reliability and consistency throughout the development and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->