### PR TITLE
encodegui-np: Update to version 1.2.3, fix download & autoupdate URLs

### DIFF
--- a/bucket/encodegui-np.json
+++ b/bucket/encodegui-np.json
@@ -1,31 +1,40 @@
 {
-    "version": "1.1.7",
-    "homepage": "https://encodegui.com/",
+    "version": "1.2.3",
+    "homepage": "https://encodegui.com",
     "description": "A free and open source video transcoder GUI that utilizes AI tools for a fascinating encoding experience.",
-    "license": "AGPL-3.0",
+    "license": {
+        "identifier": "AGPL-3.0-or-later",
+        "url": "https://github.com/DaGooseYT/EncodeGUI/blob/HEAD/LICENSE"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://encodegui.com/dl/EncodeGUI_1.1.7_setup.zip",
-            "hash": "14ea53d61360b8874863662e8deadaea4efc705c62ac59d8ec5e2bee66cb8765"
+            "url": "https://www.encodegui.com/dl/EncodeGUI_v1.2.3_win_setup.zip",
+            "hash": "a8c7323a0e2142575ed052e3ff81d9daf711bb3dc90edbc1058ba5890202e0de"
         }
     },
-    "post_install": [
-        "Get-ChildItem \"$dir\\EncodeGUI*setup.exe\" | Rename-Item -NewName 'setup.exe'; $arguments = @('/VERYSILENT', '/CURRENTUSER', \"/DIR=$dir\", '/SUPPRESSMSGBOXES')",
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "Start-Process \"$dir\\setup.exe\" -Wait -Verb 'RunAs' -ArgumentList $arguments; Remove-Item \"$dir\\setup.exe\""
-    ],
-    "pre_uninstall": [
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "Start-Process \"$dir\\unins000.exe\" -Wait -Verb 'RunAs' -ArgumentList @('/VERYSILENT', '/FORCECLOSEAPPLICATIONS', '/SUPPRESSMSGBOXES')",
-        "Start-Sleep -Seconds 2"
-    ],
+    "pre_install": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
+    "installer": {
+        "script": [
+            "$args_list = @('/VERYSILENT', \"/DIR=`\"$dir`\"\", '/SUPPRESSMSGBOXES')",
+            "$installer_file = Get-ChildItem -Path $dir -Filter '*.exe' -File | Select-Object -ExpandProperty FullName -First 1",
+            "Start-Process -FilePath $installer_file -ArgumentList $args_list -WindowStyle Hidden -Wait",
+            "Remove-Item -Path $installer_file -Force -ErrorAction SilentlyContinue"
+        ]
+    },
+    "pre_uninstall": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
+    "uninstaller": {
+        "script": [
+            "$args_list = @('/VERYSILENT', '/FORCECLOSEAPPLICATIONS', '/SUPPRESSMSGBOXES')",
+            "Start-Process -FilePath \"$dir\\unins000.exe\" -ArgumentList $args_list -WindowStyle Hidden -Wait"
+        ]
+    },
     "checkver": {
         "github": "https://github.com/DaGooseYT/EncodeGUI"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://encodegui.com/dl/EncodeGUI_$version_setup.zip"
+                "url": "https://www.encodegui.com/dl/EncodeGUI_v$version_win_setup.zip"
             }
         }
     }


### PR DESCRIPTION
### Summary

Updates `encodegui-np` to version **1.2.3**, refactors the installation/uninstallation scripts for better reliability, and improves manifest metadata.

### Related issues or pull requests

- Relates to #548  

### Changes

- **Update** version to **1.2.3**.
- **Enhance** Metadata:
  - Update `license` to use the full SPDX identifier (`AGPL-3.0-or-later`) with a direct URL.
  - Standardize `homepage` and `url` formats.
- **Refactor** installation logic:
  - Move logic from `post_install` to the standard `installer` field.
  - Improve installer executable detection using `Get-ChildItem` with dynamic filtering.
  - Add `-WindowStyle Hidden` for a cleaner background installation experience.
- **Improve** Permission Handling:
  - Replace generic error messages with a more robust `is_admin` check in `pre_install` and `pre_uninstall`.
  - Switche from `error` to `abort` for cleaner termination when admin rights are missing.
- **Fix** `autoupdate`: Adjusted the URL pattern to match the new `v$version_win_setup.zip` format used by the vendor.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\encodegui-np.json' -f
encodegui-np: 1.2.3 (scoop version is 1.2.3)
Forcing autoupdate!
Autoupdating encodegui-np
DEBUG[1770565236] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1770565236] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1770565236] $substitutions.$dotVersion                    1.2.3
DEBUG[1770565236] $substitutions.$underscoreVersion             1_2_3
DEBUG[1770565236] $substitutions.$version                       1.2.3
DEBUG[1770565236] $substitutions.$minorVersion                  2
DEBUG[1770565236] $substitutions.$patchVersion                  3
DEBUG[1770565236] $substitutions.$buildVersion
DEBUG[1770565236] $substitutions.$matchTail
DEBUG[1770565236] $substitutions.$urlNoExt                      https://www.encodegui.com/dl/EncodeGUI_v1.2.3_win_setup
DEBUG[1770565236] $substitutions.$url                           https://www.encodegui.com/dl/EncodeGUI_v1.2.3_win_setup.zip
DEBUG[1770565236] $substitutions.$dashVersion                   1-2-3
DEBUG[1770565236] $substitutions.$basenameNoExt                 EncodeGUI_v1.2.3_win_setup
DEBUG[1770565236] $substitutions.$matchHead                     1.2.3
DEBUG[1770565236] $substitutions.$basename                      EncodeGUI_v1.2.3_win_setup.zip
DEBUG[1770565236] $substitutions.$preReleaseVersion             1.2.3
DEBUG[1770565236] $substitutions.$cleanVersion                  123
DEBUG[1770565236] $substitutions.$majorVersion                  1
DEBUG[1770565236] $substitutions.$baseurl                       https://www.encodegui.com/dl
DEBUG[1770565236] $substitutions.$match1                        1.2.3
DEBUG[1770565236] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Downloading EncodeGUI_v1.2.3_win_setup.zip to compute hashes!
Loading EncodeGUI_v1.2.3_win_setup.zip from cache
Computed hash: a8c7323a0e2142575ed052e3ff81d9daf711bb3dc90edbc1058ba5890202e0de
Writing updated encodegui-np manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\encodegui-np.json'
Installing 'encodegui-np' (1.2.3) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\encodegui-np.json'
Loading EncodeGUI_v1.2.3_win_setup.zip from cache.
Checking hash of EncodeGUI_v1.2.3_win_setup.zip... OK.
Extracting EncodeGUI_v1.2.3_win_setup.zip... Done.
Running pre_install script... Done.
Running installer script... Done.
Linking D:\Software\Scoop\Local\apps\encodegui-np\current => D:\Software\Scoop\Local\apps\encodegui-np\1.2.3
'encodegui-np' (1.2.3) was installed successfully!

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop uninstall encodegui-np -p
Uninstalling 'encodegui-np' (1.2.3).
Running pre_uninstall script... Done.
Running uninstaller script... Done.
Unlinking D:\Software\Scoop\Local\apps\encodegui-np\current
Removing persisted data.
'encodegui-np' was uninstalled.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 1.2.3
  * Enhanced installation and uninstallation procedures with improved admin verification
  * Updated license information and download URLs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->