### PR TITLE
mullvadvpn-np: Fix checkver, add arm64 version

### DIFF
--- a/bucket/mullvadvpn-np.json
+++ b/bucket/mullvadvpn-np.json
@@ -11,10 +11,6 @@
             "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/2025.14/MullvadVPN-2025.14_x64.exe",
             "hash": "332a1f05bc367a199f0a17fb1e19d3ffcbf79a5024bced619c9e771d31281830"
         },
-        "32bit": {
-            "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/2025.14/MullvadVPN-2025.14.exe",
-            "hash": "cd9262981a9b30c48d7014b8b355a1e5adfcfb86b01cab25766de68d15fccd7b"
-        },
         "arm64": {
             "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/2025.14/MullvadVPN-2025.14_arm64.exe",
             "hash": "4e08b1aa64aa9cde1a7290705a337b50b58d3a7cc4c317a979fd9507ee308309"
@@ -35,19 +31,16 @@
     },
     "checkver": {
         "url": "https://api.github.com/repositories/114742422/releases",
-        "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /\\.exe$/i)].browser_download_url",
-        "regex": "(?i)download/(?<tag>[^/]+)/MullvadVPN-([\\d.]+)_(?:x|arm)64"
+        "jsonpath": "$[*].assets[?(@.name =~ /\\.exe$/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/MullvadVPN-([\\w.-]+)_(?:x|arm)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/$matchTag/MullvadVPN-$version_x64.exe"
-            },
-            "32bit": {
-                "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/$matchTag/MullvadVPN-$version.exe"
+                "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/$version/MullvadVPN-$version_x64.exe"
             },
             "arm64": {
-                "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/$matchTag/MullvadVPN-$version_arm64.exe"
+                "url": "https://github.com/mullvad/mullvadvpn-app/releases/download/$version/MullvadVPN-$version_arm64.exe"
             }
         }
     }


### PR DESCRIPTION
### Summary

Refructures `mullvadvpn-np` manifest to support multiple architectures and implements robust GitHub API-based `checkver` logic for more accurate updates.

### Related issues or pull requests

- Relates to #548 
- Relates to #521 

### Changes

- **Improve license field**: Update to use an object with SPDX identifier `GPL-3.0-or-later` and a direct link to the license file.
- **Add multi-architecture support**: Expand the manifest to include `arm64` architectures, providing full coverage for Windows devices.
- **Update checkver logic**: 
  - Switch from the basic `github` helper to the GitHub API.
  - Implement `jsonpath` to filter for `.exe` assets.
  - Add a named capture group `tag` to correctly extract and map `$matchTag`.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\mullvadvpn-np.json' -f
mullvadvpn-np: 2025.14 (scoop version is 2025.14)
Forcing autoupdate!
Autoupdating mullvadvpn-np
DEBUG[1771752714] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1771752714] $substitutions.$matchTag                      2025.14
DEBUG[1771752714] $substitutions.$baseurl                       https://github.com/mullvad/mullvadvpn-app/releases/download/2025.14
DEBUG[1771752714] $substitutions.$majorVersion                  2025
DEBUG[1771752714] $substitutions.$preReleaseVersion             2025.14
DEBUG[1771752714] $substitutions.$minorVersion                  14
DEBUG[1771752714] $substitutions.$basename                      MullvadVPN-2025.14_arm64.exe
DEBUG[1771752714] $substitutions.$url                           https://github.com/mullvad/mullvadvpn-app/releases/download/2025.14/MullvadVPN-2025.14_arm64.exe
DEBUG[1771752714] $substitutions.$buildVersion
DEBUG[1771752714] $substitutions.$basenameNoExt                 MullvadVPN-2025.14_arm64
DEBUG[1771752714] $substitutions.$matchTail
DEBUG[1771752714] $substitutions.$underscoreVersion             2025_14
DEBUG[1771752714] $substitutions.$match1                        2025.14
DEBUG[1771752714] $substitutions.$version                       2025.14
DEBUG[1771752714] $substitutions.$urlNoExt                      https://github.com/mullvad/mullvadvpn-app/releases/download/2025.14/MullvadVPN-2025.14_arm64
DEBUG[1771752714] $substitutions.$patchVersion
DEBUG[1771752714] $substitutions.$dotVersion                    2025.14
DEBUG[1771752714] $substitutions.$cleanVersion                  202514
DEBUG[1771752714] $substitutions.$matchHead                     2025.14
DEBUG[1771752714] $substitutions.$dashVersion                   2025-14
DEBUG[1771752714] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1771752717] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/mullvad/mullvadvpn-app/releases/download/2025.14/MullvadVPN-2025.14_arm64.exe')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: 4e08b1aa64aa9cde1a7290705a337b50b58d3a7cc4c317a979fd9507ee308309 using Github Mode
Writing updated mullvadvpn-np manifest

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added ARM64 platform support for broader device compatibility.

* **Chores**
  - Enhanced license metadata with a clear identifier and official source URL.
  - Improved automated release detection and update URLs for more reliable versioning and installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->