### PR TITLE
sshfs-np: Update to version 3.7.21011, fix checkver & autoupdate

### DIFF
--- a/bucket/sshfs-np.json
+++ b/bucket/sshfs-np.json
@@ -1,7 +1,7 @@
 {
     "version": "3.7.21011",
     "description": "SSHFS For Windows",
-    "homepage": "http://www.github.com/billziss-gh/sshfs-win",
+    "homepage": "https://winfsp.dev",
     "license": {
         "identifier": "GPL-2.0-or-later",
         "url": "https://github.com/winfsp/sshfs-win/blob/HEAD/License.txt"


### PR DESCRIPTION
### Summary

Updates `sshfs-np` to version **3.7.21011**, adds mandatory admin right checks, and modernizes the installer/checkver logic.

### Related issues or pull requests

- Relates to #548 

### Changes

- Update version to **3.7.21011**.
- **Improve License**: Updated the `license` field to a structured object containing the SPDX identifier and a direct link to the license file.
- **Add Admin Requirement**: Introduced `pre_install` and `pre_uninstall` scripts to ensure the user has administrative privileges, as MSI installation requires them.
- **Robust checkver**: 
  - Migrate to GitHub API with `jsonpath` for dynamic asset detection.
  - Add a named capture group `tag` to accurately map the release tag for `autoupdate`.
- **Refine autoupdate**: Updated URLs to use `$matchTag`, ensuring compatibility with upstream's tagging convention.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\sshfs-np.json' -f
sshfs-np: 3.7.21011 (scoop version is 3.7.21011)
Forcing autoupdate!
Autoupdating sshfs-np
DEBUG[1772089259] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1772089259] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1772089259] $substitutions.$cleanVersion                  3721011
DEBUG[1772089259] $substitutions.$dotVersion                    3.7.21011
DEBUG[1772089259] $substitutions.$basename                      sshfs-win-3.7.21011-x86.msi
DEBUG[1772089259] $substitutions.$matchTail
DEBUG[1772089259] $substitutions.$match1                        3.7.21011
DEBUG[1772089259] $substitutions.$basenameNoExt                 sshfs-win-3.7.21011-x86
DEBUG[1772089259] $substitutions.$dashVersion                   3-7-21011
DEBUG[1772089259] $substitutions.$majorVersion                  3
DEBUG[1772089259] $substitutions.$patchVersion                  21011
DEBUG[1772089259] $substitutions.$preReleaseVersion             3.7.21011
DEBUG[1772089259] $substitutions.$matchTag                      v3.7.21011
DEBUG[1772089259] $substitutions.$underscoreVersion             3_7_21011
DEBUG[1772089259] $substitutions.$buildVersion
DEBUG[1772089259] $substitutions.$minorVersion                  7
DEBUG[1772089259] $substitutions.$urlNoExt                      https://github.com/billziss-gh/sshfs-win/releases/download/v3.7.21011/sshfs-win-3.7.21011-x86
DEBUG[1772089259] $substitutions.$url                           https://github.com/billziss-gh/sshfs-win/releases/download/v3.7.21011/sshfs-win-3.7.21011-x86.msi
DEBUG[1772089259] $substitutions.$baseurl                       https://github.com/billziss-gh/sshfs-win/releases/download/v3.7.21011
DEBUG[1772089259] $substitutions.$matchHead                     3.7.21011
DEBUG[1772089259] $substitutions.$version                       3.7.21011
DEBUG[1772089259] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1772089260] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/billziss-gh/sshfs-win/releases/download/v3.7.21011/sshfs-win-3.7.21011-x86.msi')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Could not find hash in https://api.github.com/repos/billziss-gh/sshfs-win/releases
Downloading sshfs-win-3.7.21011-x86.msi to compute hashes!
Loading sshfs-win-3.7.21011-x86.msi from cache
Computed hash: f74e399a44b54b447f7e8ed4f012ba1932c5f90be71a6942ea304841eab610b0
DEBUG[1772089260] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1772089260] $substitutions.$cleanVersion                  3721011
DEBUG[1772089260] $substitutions.$dotVersion                    3.7.21011
DEBUG[1772089260] $substitutions.$basename                      sshfs-win-3.7.21011-x64.msi
DEBUG[1772089260] $substitutions.$matchTail
DEBUG[1772089260] $substitutions.$match1                        3.7.21011
DEBUG[1772089260] $substitutions.$basenameNoExt                 sshfs-win-3.7.21011-x64
DEBUG[1772089260] $substitutions.$dashVersion                   3-7-21011
DEBUG[1772089260] $substitutions.$majorVersion                  3
DEBUG[1772089260] $substitutions.$patchVersion                  21011
DEBUG[1772089260] $substitutions.$preReleaseVersion             3.7.21011
DEBUG[1772089260] $substitutions.$matchTag                      v3.7.21011
DEBUG[1772089260] $substitutions.$underscoreVersion             3_7_21011
DEBUG[1772089260] $substitutions.$buildVersion
DEBUG[1772089260] $substitutions.$minorVersion                  7
DEBUG[1772089260] $substitutions.$urlNoExt                      https://github.com/billziss-gh/sshfs-win/releases/download/v3.7.21011/sshfs-win-3.7.21011-x64
DEBUG[1772089260] $substitutions.$url                           https://github.com/billziss-gh/sshfs-win/releases/download/v3.7.21011/sshfs-win-3.7.21011-x64.msi
DEBUG[1772089260] $substitutions.$baseurl                       https://github.com/billziss-gh/sshfs-win/releases/download/v3.7.21011
DEBUG[1772089260] $substitutions.$matchHead                     3.7.21011
DEBUG[1772089260] $substitutions.$version                       3.7.21011
DEBUG[1772089260] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1772089261] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/billziss-gh/sshfs-win/releases/download/v3.7.21011/sshfs-win-3.7.21011-x64.msi')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Could not find hash in https://api.github.com/repos/billziss-gh/sshfs-win/releases
Downloading sshfs-win-3.7.21011-x64.msi to compute hashes!
Loading sshfs-win-3.7.21011-x64.msi from cache
Computed hash: 76080d7bfb1ba0a807f8874d07388bec4bc30893f2da511d5cb7a16d4490f7d1
Writing updated sshfs-np manifest

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installation and uninstallation now require administrator privileges.
  * Added dependency on winfsp-np.

* **Chores**
  * Updated to version 3.7.21011 with refreshed download URLs and file hashes.
  * Improved installer/uninstaller handling for silent execution.
  * Enhanced version-checking and autoupdate templates for more reliable updates.
  * Homepage and license declaration updated with a license URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->