### PR TITLE
files-np@4.0.28.0: Fix hash

### DIFF
--- a/bucket/files-np.json
+++ b/bucket/files-np.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://cdn.files.community/files/stable/Files.Package_4.0.28.0_Test/Files.Package_4.0.28.0_x64_arm64.msixbundle",
-            "hash": "0285d8732dfb18c6d23175db4317506a668ae2c2e9be0c7cf3ae98aba73784f1"
+            "hash": "942971e67ef9d19ba3f065d46bb2ed04faf3082c845f4950d4abe1f823731712"
         }
     },
     "installer": {


### PR DESCRIPTION
- Closes #566 

```powershell
┏[ ~]
└─> sha256sum "D:\Download\Default\Files.Package_4.0.28.0_x64_arm64.msixbundle"
\942971e67ef9d19ba3f065d46bb2ed04faf3082c845f4950d4abe1f823731712  D:\\Download\\Default\\Files.Package_4.0.28.0_x64_arm64.msixbundle

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop download 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Nonportable\bucket\files-np.json'
INFO  Downloading 'files-np' [64bit]
Starting download with aria2...
Download: Download Results:
Download: gid   |stat|avg speed  |  %|path/URI
Download: ======+====+===========+===+===================================================
Download: 6485f2|OK  |   2.1MiB/s|100|D:/Software/Scoop/Local/cache/files-np#4.0.28.0#3dcd7b9.msixbundle
Download: Status Legend:
Download: (OK):download completed.
Checking hash of Files.Package_4.0.28.0_x64_arm64.msixbundle... OK.
'files-np' (4.0.28.0) was downloaded successfully!
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->