### PR TITLE
autohotkey-np: Fix (un)installation script logic

### DIFF
--- a/bucket/autohotkey-np.json
+++ b/bucket/autohotkey-np.json
@@ -7,7 +7,7 @@
     "hash": "d7038e9ba08e9c63edcdb2e63552b434b87491b449d7082cf28a40cd4ece91af",
     "installer": {
         "script": [
-            "if ($global) { error \"Global install currently not supported due to uninstall issue https://github.com/ScoopInstaller/Scoop/issues/6452\"; break }",
+            "if ($global) { abort \"`n[ERROR]  Global install currently not supported due to uninstall issue https://github.com/ScoopInstaller/Scoop/issues/6452\" }",
             "$arguments = @('/installto', \"$dir\", '/silent')",
             "if ($global) { $arguments += '/elevate' } else { $arguments += '/user' }",
             "Invoke-ExternalCommand \"$dir/setup.exe\" -ArgumentList $arguments"

--- a/bucket/autohotkey-np.json
+++ b/bucket/autohotkey-np.json
@@ -16,7 +16,6 @@
     "uninstaller": {
         "script": [
             "$globaltest = $False",
-            "if (($globaltest) -And !(is_admin)) { error \"Admin rights required to uninstall globally\"; break }",
             "$arguments = @('/uninstall', '/to', \"$dir\", '/silent')",
             "if ($globaltest) { $arguments += '/elevate' } else { $arguments += '/user' }",
             "Invoke-ExternalCommand \"$dir/setup.exe\" -ArgumentList $arguments",

--- a/bucket/autohotkey-np.json
+++ b/bucket/autohotkey-np.json
@@ -3,7 +3,7 @@
     "description": "The ultimate automation scripting language for Windows.",
     "homepage": "https://www.autohotkey.com/",
     "license": "GPL-2.0-or-later",
-    "url": "https://www.autohotkey.com/download/2.0/AutoHotkey_2.0.23_setup.exe#/setup.exe",
+    "url": "https://github.com/AutoHotkey/AutoHotkey/releases/download/v2.0.23/AutoHotkey_2.0.23_setup.exe#/setup.exe",
     "hash": "d7038e9ba08e9c63edcdb2e63552b434b87491b449d7082cf28a40cd4ece91af",
     "installer": {
         "script": [
@@ -25,13 +25,9 @@
         ]
     },
     "checkver": {
-        "url": "https://www.autohotkey.com/download/2.0/version.txt",
-        "regex": "([\\d.]+)"
+        "github": "https://github.com/AutoHotkey/AutoHotkey"
     },
     "autoupdate": {
-        "url": "https://www.autohotkey.com/download/$majorVersion.$minorVersion/AutoHotkey_$version_setup.exe#/setup.exe",
-        "hash": {
-            "url": "$url.sha256"
-        }
+        "url": "https://github.com/AutoHotkey/AutoHotkey/releases/download/v$version/AutoHotkey_$version_setup.exe#/setup.exe"
     }
 }

--- a/bucket/autohotkey-np.json
+++ b/bucket/autohotkey-np.json
@@ -8,7 +8,6 @@
     "installer": {
         "script": [
             "if ($global) { error \"Global install currently not supported due to uninstall issue https://github.com/ScoopInstaller/Scoop/issues/6452\"; break }",
-            "if (($global) -And !(is_admin)) { error \"Admin rights required to install globally\"; break }",
             "$arguments = @('/installto', \"$dir\", '/silent')",
             "if ($global) { $arguments += '/elevate' } else { $arguments += '/user' }",
             "Invoke-ExternalCommand \"$dir/setup.exe\" -ArgumentList $arguments"

--- a/bucket/autohotkey-np.json
+++ b/bucket/autohotkey-np.json
@@ -3,53 +3,34 @@
     "description": "The ultimate automation scripting language for Windows.",
     "homepage": "https://www.autohotkey.com/",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v2.0.23/AutoHotkey_2.0.23_setup.exe#/setup.exe",
+    "url": "https://www.autohotkey.com/download/2.0/AutoHotkey_2.0.23_setup.exe#/setup.exe",
     "hash": "d7038e9ba08e9c63edcdb2e63552b434b87491b449d7082cf28a40cd4ece91af",
-    "pre_install": "Write-Host 'Installing AutoHotKey with their installer and its own options ( create registry keys removed by uninstaller )' -ForegroundColor Magenta",
-    "architecture": {
-        "64bit": {
-            "installer": {
-                "script": [
-                    "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-                    "Start-Process -Wait \"$dir\\setup.exe\" -ArgumentList @('/S', '/x64', '/uiAccess=0', '/IsHostApp=1', \"/D=`\"$dir`\"\") -Verb RunAs | Out-Null"
-                ]
-            },
-            "bin": [
-                "autohotkeyu64.exe",
-                [
-                    "autohotkeyu64.exe",
-                    "autohotkey"
-                ],
-                "compiler\\ahk2exe.exe"
-            ]
-        },
-        "32bit": {
-            "installer": {
-                "script": [
-                    "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-                    "Start-Process -Wait \"$dir\\setup.exe\" -ArgumentList @('/S', '/U32', '/uiAccess=0', '/IsHostApp=1', \"/D=`\"$dir`\"\") -Verb RunAs | Out-Null"
-                ]
-            },
-            "bin": [
-                "autohotkeyu32.exe",
-                [
-                    "autohotkeyu32.exe",
-                    "autohotkey"
-                ],
-                "compiler\\ahk2exe.exe"
-            ]
-        }
+    "installer": {
+        "script": [
+            "if ($global) { error \"Global install currently not supported due to uninstall issue https://github.com/ScoopInstaller/Scoop/issues/6452\"; break }",
+            "if (($global) -And !(is_admin)) { error \"Admin rights required to install globally\"; break }",
+            "$arguments = @('/installto', \"$dir\", '/silent')",
+            "if ($global) { $arguments += '/elevate' } else { $arguments += '/user' }",
+            "Invoke-ExternalCommand \"$dir/setup.exe\" -ArgumentList $arguments"
+        ]
     },
     "uninstaller": {
         "script": [
-            "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-            "Start-Process -Wait \"$dir\\setup.exe\" -ArgumentList '/Uninstall' -Verb RunAs | Out-Null"
+            "$globaltest = $False",
+            "if (($globaltest) -And !(is_admin)) { error \"Admin rights required to uninstall globally\"; break }",
+            "$arguments = @('/uninstall', '/to', \"$dir\", '/silent')",
+            "if ($globaltest) { $arguments += '/elevate' } else { $arguments += '/user' }",
+            "Invoke-ExternalCommand \"$dir/setup.exe\" -ArgumentList $arguments"
         ]
     },
     "checkver": {
-        "github": "https://github.com/lexikos/autohotkey_l"
+        "url": "https://www.autohotkey.com/download/2.0/version.txt",
+        "regex": "([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v$version/AutoHotkey_$version_setup.exe#/setup.exe"
+        "url": "https://www.autohotkey.com/download/$majorVersion.$minorVersion/AutoHotkey_$version_setup.exe#/setup.exe",
+        "hash": {
+            "url": "$url.sha256"
+        }
     }
 }

--- a/bucket/autohotkey-np.json
+++ b/bucket/autohotkey-np.json
@@ -8,7 +8,7 @@
     "installer": {
         "script": [
             "if ($global) { error \"Global install currently not supported due to uninstall issue https://github.com/ScoopInstaller/Scoop/issues/6452\"; break }",
-            "$arguments = @('/installto', \"$dir\", '/silent')",
+            "$arguments = @('/installto', \"`\"$dir`\"\", '/silent')",
             "if ($global) { $arguments += '/elevate' } else { $arguments += '/user' }",
             "Invoke-ExternalCommand \"$dir\\$fname\" -ArgumentList $arguments"
         ]

--- a/bucket/autohotkey-np.json
+++ b/bucket/autohotkey-np.json
@@ -19,7 +19,7 @@
             "$arguments = @('/uninstall', '/to', \"$dir\", '/silent')",
             "if ($globaltest) { $arguments += '/elevate' } else { $arguments += '/user' }",
             "Invoke-ExternalCommand \"$dir/setup.exe\" -ArgumentList $arguments",
-            "Remove-Item \"$dir/setup.exe\" -Force"
+            "Remove-Item -Path \"$dir\\setup.exe\" -Force -ErrorAction SilentlyContinue"
         ]
     },
     "checkver": {

--- a/bucket/autohotkey-np.json
+++ b/bucket/autohotkey-np.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.0.23",
+    "version": "2.0.24",
     "description": "The ultimate automation scripting language for Windows.",
     "homepage": "https://www.autohotkey.com/",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/AutoHotkey/AutoHotkey/releases/download/v2.0.23/AutoHotkey_2.0.23_setup.exe#/setup.exe",
-    "hash": "d7038e9ba08e9c63edcdb2e63552b434b87491b449d7082cf28a40cd4ece91af",
+    "url": "https://github.com/AutoHotkey/AutoHotkey/releases/download/v2.0.24/AutoHotkey_2.0.24_setup.exe#/setup.exe",
+    "hash": "a945f745506cf93e41c1fca2006d1f2fe39e07355f37ca357f90f74cca8a61d4",
     "installer": {
         "script": [
             "if ($global) { abort \"`n[ERROR]  Global install currently not supported due to uninstall issue https://github.com/ScoopInstaller/Scoop/issues/6452\" }",

--- a/bucket/autohotkey-np.json
+++ b/bucket/autohotkey-np.json
@@ -8,7 +8,7 @@
     "installer": {
         "script": [
             "if ($global) { abort \"`n[ERROR]  Global install currently not supported due to uninstall issue https://github.com/ScoopInstaller/Scoop/issues/6452\" }",
-            "$arguments = @('/installto', \"`\"$dir`\"\", '/silent')",
+            "$arguments = @('/installto', $dir, '/silent')",
             "if ($global) { $arguments += '/elevate' } else { $arguments += '/user' }",
             "Invoke-ExternalCommand \"$dir\\$fname\" -ArgumentList $arguments"
         ]
@@ -16,7 +16,7 @@
     "uninstaller": {
         "script": [
             "$globaltest = $False",
-            "$arguments = @('/uninstall', '/to', \"$dir\", '/silent')",
+            "$arguments = @('/uninstall', '/to', $dir, '/silent')",
             "if ($globaltest) { $arguments += '/elevate' } else { $arguments += '/user' }",
             "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList $arguments",
             "Remove-Item -Path \"$dir\\setup.exe\" -Force -ErrorAction SilentlyContinue"

--- a/bucket/autohotkey-np.json
+++ b/bucket/autohotkey-np.json
@@ -10,7 +10,7 @@
             "if ($global) { error \"Global install currently not supported due to uninstall issue https://github.com/ScoopInstaller/Scoop/issues/6452\"; break }",
             "$arguments = @('/installto', \"$dir\", '/silent')",
             "if ($global) { $arguments += '/elevate' } else { $arguments += '/user' }",
-            "Invoke-ExternalCommand \"$dir/setup.exe\" -ArgumentList $arguments"
+            "Invoke-ExternalCommand \"$dir\\$fname\" -ArgumentList $arguments"
         ]
     },
     "uninstaller": {
@@ -18,8 +18,8 @@
             "$globaltest = $False",
             "$arguments = @('/uninstall', '/to', \"$dir\", '/silent')",
             "if ($globaltest) { $arguments += '/elevate' } else { $arguments += '/user' }",
-            "Invoke-ExternalCommand \"$dir/setup.exe\" -ArgumentList $arguments",
-            "Remove-Item \"$dir/setup.exe\" -Force"
+            "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList $arguments",
+            "Remove-Item \"$dir\\setup.exe\" -Force"
         ]
     },
     "checkver": {

--- a/bucket/autohotkey-np.json
+++ b/bucket/autohotkey-np.json
@@ -20,7 +20,8 @@
             "if (($globaltest) -And !(is_admin)) { error \"Admin rights required to uninstall globally\"; break }",
             "$arguments = @('/uninstall', '/to', \"$dir\", '/silent')",
             "if ($globaltest) { $arguments += '/elevate' } else { $arguments += '/user' }",
-            "Invoke-ExternalCommand \"$dir/setup.exe\" -ArgumentList $arguments"
+            "Invoke-ExternalCommand \"$dir/setup.exe\" -ArgumentList $arguments",
+            "Remove-Item \"$dir/setup.exe\" -Force"
         ]
     },
     "checkver": {


### PR DESCRIPTION
Fixes manifest to allow autohotkey v2 installation.

The manifest was not compatible with newer version 2 of autohotkey and had to be modified.
Older version 1 is still available in `versions/autohotkey1`

Closes https://github.com/ScoopInstaller/Nonportable/issues/424

- Switches github url from old to new one. Matches `extras/autohotkey`.
- Fixes (un)installer to match new version 2 installation procedure.
- Prepares for global (un)installation, once https://github.com/ScoopInstaller/Scoop/issues/6452 is fixed
- Only provides 32bit installer, which the 64bit versions fall back to.

Tests:
✅ [Virustotal 0/95](https://www.virustotal.com/gui/url/e7b24814cd23a2dcb3eb29aab94565f5c99b20a5a892ae3199babb6eb46e389b)
✅ `.\bin\formatjson.ps1 -App autohotkey-np`
✅ (Non-)Admin (Un)Install
✅ Non-Admin Update from 2.0.22 to 2.0.23
❌ Global installation aborts, as intended.
❌ Removes old version on update, since scoop switching between versions is not supported. The installer creates Start menu entries only for the latest installed variant.

I did not investigate if the `extras/autohotkey` package is equal in user-experience to this one. Maybe only one of these should be kept to reduce maintenance in the future.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched package source to the official upstream AutoHotkey releases to ensure downloads and updates come from the maintained project.
  * Consolidated the install flow into a single installer that cleanly supports both per-user and elevated (system) installations.
  * Simplified uninstall to reliably remove per-user or global installs and clean up installer artifacts.
  * Removed legacy architecture-specific installer paths and prior pre-install messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->