### PR TITLE
link-shell-extension-np: Add version 3.9.3.5

### DIFF
--- a/bucket/link-shell-extension-np.json
+++ b/bucket/link-shell-extension-np.json
@@ -1,6 +1,6 @@
 {
     "version": "3.9.3.5",
-    "description": "Link Shell Extension. Offers  the creation of Hardlinks, Junctions, Volume Mountpoints, Symbolic Links and a folder cloning or copy process.",
+    "description": "Link Shell Extension. Offers the creation of Hardlinks, Junctions, Volume Mountpoints, Symbolic Links and a folder cloning or copy process.",
     "homepage": "https://schinagl.priv.at/nt/hardlinkshellext/hardlinkshellext.html",
     "license": {
         "identifier": "Proprietary",

--- a/bucket/link-shell-extension-np.json
+++ b/bucket/link-shell-extension-np.json
@@ -1,0 +1,56 @@
+{
+    "version": "3.9.3.5",
+    "description": "Link Shell Extension. Offers  the creation of Hardlinks, Junctions, Volume Mountpoints, Symbolic Links and a folder cloning or copy process.",
+    "homepage": "https://schinagl.priv.at/nt/hardlinkshellext/hardlinkshellext.html",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://schinagl.priv.at/nt/hardlinkshellext/license.txt"
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://schinagl.priv.at/nt/hardlinkshellext/save/3935/HardLinkShellExt_X64.exe#/HardLinkShellExt.exe",
+            "hash": "ca3f26ebf49dc4ea8b5d8c0154acca0de59a8689e5907fe748ffaeaa357ff3a0"
+        },
+        "32bit": {
+            "url": "https://schinagl.priv.at/nt/hardlinkshellext/save/3935/HardLinkShellExt_win32.exe#/HardLinkShellExt.exe",
+            "hash": "b7e7227e960f025be992c398dafacd03c416adf5210d3fc0ff1d5b5771afdc4b"
+        }
+    },
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand -FilePath \"$dir\\HardLinkShellExt.exe\" -Args @('/S', '/noredist', '/Language=English', \"/D=$dir\") -RunAs | Out-Null",
+            "Remove-Item \"$dir\\HardLinkShellExt.exe\" -ErrorAction SilentlyContinue"
+        ]
+    },
+    "uninstaller": {
+        "64bit": {
+            "script": "Invoke-ExternalCommand -FilePath \"$dir\\uninst-HardLinkShellExt_X64.exe\" -Args @('/S' , '/noredist') -RunAs | Out-Null"
+        },
+        "32bit": {
+            "script": "Invoke-ExternalCommand -FilePath \"$dir\\uninst-HardLinkShellExt_win32.exe\" -Args @('/S' , '/noredist') -RunAs | Out-Null"
+        }
+    },
+    "shortcuts": [
+        [
+            "LSEConfig.exe",
+            "Link Shell Extension Configuration"
+        ]
+    ],
+    "checkver": {
+        "url": "https://schinagl.priv.at/nt/hardlinkshellext/hardlinkshellext.html",
+        "regex": ">Last Updated .+ Version ([\\d.]+)<"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://schinagl.priv.at/nt/hardlinkshellext/save/$cleanVersion/HardLinkShellExt_X64.exe#/HardLinkShellExt.exe"
+            },
+            "32bit": {
+                "url": "https://schinagl.priv.at/nt/hardlinkshellext/save/$cleanVersion/HardLinkShellExt_win32.exe#/HardLinkShellExt.exe"
+            }
+        }
+    }
+}

--- a/bucket/link-shell-extension-np.json
+++ b/bucket/link-shell-extension-np.json
@@ -1,6 +1,6 @@
 {
     "version": "3.9.3.5",
-    "description": "Link Shell Extension. Offers the creation of Hardlinks, Junctions, Volume Mountpoints, Symbolic Links and a folder cloning or copy process.",
+    "description": "Link Shell Extension. Offers  the creation of Hardlinks, Junctions, Volume Mountpoints, Symbolic Links and a folder cloning or copy process.",
     "homepage": "https://schinagl.priv.at/nt/hardlinkshellext/hardlinkshellext.html",
     "license": {
         "identifier": "Proprietary",

--- a/bucket/link-shell-extension-np.json
+++ b/bucket/link-shell-extension-np.json
@@ -1,6 +1,6 @@
 {
     "version": "3.9.3.5",
-    "description": "Link Shell Extension. Offers the creation of Hardlinks, Junctions, Volume Mountpoints, Symbolic Links and a folder cloning or copy process.",
+    "description": "A Windows shell extension for creating and managing NTFS links, including Hardlinks, Junctions, Volume Mountpoints, and Symbolic Links, directly through the file manager interface.",
     "homepage": "https://schinagl.priv.at/nt/hardlinkshellext/hardlinkshellext.html",
     "license": {
         "identifier": "Proprietary",
@@ -19,29 +19,26 @@
             "hash": "b7e7227e960f025be992c398dafacd03c416adf5210d3fc0ff1d5b5771afdc4b"
         }
     },
+    "pre_install": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
     "installer": {
         "script": [
-            "Invoke-ExternalCommand -FilePath \"$dir\\HardLinkShellExt.exe\" -Args @('/S', '/noredist', '/Language=English', \"/D=$dir\") -RunAs | Out-Null",
-            "Remove-Item \"$dir\\HardLinkShellExt.exe\" -ErrorAction SilentlyContinue"
+            "$install_args = @('/S', '/noredist', '/Language=English', \"/D=$dir\")",
+            "Start-Process -FilePath \"$dir\\$fname\" -ArgumentList $install_args -WindowStyle Hidden -Wait",
+            "Remove-Item -Path \"$dir\\$fname\" -Force -ErrorAction SilentlyContinue"
         ]
     },
+    "pre_uninstall": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
     "uninstaller": {
-        "64bit": {
-            "script": "Invoke-ExternalCommand -FilePath \"$dir\\uninst-HardLinkShellExt_X64.exe\" -Args @('/S' , '/noredist') -RunAs | Out-Null"
-        },
-        "32bit": {
-            "script": "Invoke-ExternalCommand -FilePath \"$dir\\uninst-HardLinkShellExt_win32.exe\" -Args @('/S' , '/noredist') -RunAs | Out-Null"
-        }
-    },
-    "shortcuts": [
-        [
-            "LSEConfig.exe",
-            "Link Shell Extension Configuration"
+        "script": [
+            "$removal_args = @('/S' , '/noredist')",
+            "$uninstaller_file = Get-ChildItem -Path $dir -Filter 'uninst*' -File | Select-Object -ExpandProperty FullName -First 1",
+            "if (-not $uninstaller_file) { abort \"`nInstallation Failed: Uninstaller not found in '$dir'.\" }",
+            "Start-Process -FilePath $uninstaller_file -ArgumentList $removal_args -WindowStyle Hidden -Wait"
         ]
-    ],
+    },
     "checkver": {
         "url": "https://schinagl.priv.at/nt/hardlinkshellext/hardlinkshellext.html",
-        "regex": ">Last Updated .+ Version ([\\d.]+)<"
+        "regex": "Last Updated.+?Version ([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Closes #577

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Link Shell Extension package offering 64‑bit and 32‑bit installers.
  * Supports silent/unattended install and uninstall for both architectures.
  * Automatic version checking and autoupdate URLs configured.
  * Includes a runtime dependency hint and integrity checks for downloads.
  * Installer actions require administrator privileges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->