### PR TITLE
leigod: Add version 11.3.1.9

### DIFF
--- a/bucket/leigod.json
+++ b/bucket/leigod.json
@@ -11,14 +11,18 @@
     "installer": {
         "script": [
             "$bytes = [System.IO.File]::ReadAllBytes(\"$dir\\$fname\")",
+            "$found = $false",
             "for ($i = 0; $i -lt $bytes.Length - 6; $i++) {",
             "    if ($bytes[$i] -eq 0x37 -and $bytes[$i+1] -eq 0x7A -and $bytes[$i+2] -eq 0xBC -and $bytes[$i+3] -eq 0xAF -and $bytes[$i+4] -eq 0x27 -and $bytes[$i+5] -eq 0x1C) {",
             "        $7zBytes = New-Object byte[] ($bytes.Length - $i)",
             "        [Array]::Copy($bytes, $i, $7zBytes, 0, $7zBytes.Length)",
             "        [System.IO.File]::WriteAllBytes(\"$dir\\leigod.7z\", $7zBytes)",
+            "        $found = $true",
             "        break",
             "    }",
             "}",
+            "if (-not $found) { throw '7z signature not found in payload' }",
+            "if (-not (Test-Path \"$dir\\leigod.7z\")) { throw 'Extracted archive not found' }",
             "Expand-7zipArchive \"$dir\\leigod.7z\" \"$dir\"",
             "Remove-Item \"$dir\\leigod.7z\" -Force",
             "Remove-Item \"$dir\\$fname\" -Force"

--- a/bucket/leigod.json
+++ b/bucket/leigod.json
@@ -1,0 +1,43 @@
+{
+    "version": "11.3.1.9",
+    "description": "LeiGod - Game accelerator for reducing latency",
+    "homepage": "https://www.leigod.com/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.leigod.com/legal/user-server"
+    },
+    "url": "https://update.leigod.com/soft/leigod/win/11.0.0.0/LeiGodSetup.11.3.1.9.exe",
+    "hash": "7540e72ba32ceff116a4eb93a8a53ef797cf34c33add5b8c6a9f57dc2fc85788",
+    "installer": {
+        "script": [
+            "$bytes = [System.IO.File]::ReadAllBytes(\"$dir\\$fname\")",
+            "for ($i = 0; $i -lt $bytes.Length - 6; $i++) {",
+            "    if ($bytes[$i] -eq 0x37 -and $bytes[$i+1] -eq 0x7A -and $bytes[$i+2] -eq 0xBC -and $bytes[$i+3] -eq 0xAF -and $bytes[$i+4] -eq 0x27 -and $bytes[$i+5] -eq 0x1C) {",
+            "        $7zBytes = New-Object byte[] ($bytes.Length - $i)",
+            "        [Array]::Copy($bytes, $i, $7zBytes, 0, $7zBytes.Length)",
+            "        [System.IO.File]::WriteAllBytes(\"$dir\\leigod.7z\", $7zBytes)",
+            "        break",
+            "    }",
+            "}",
+            "Expand-7zipArchive \"$dir\\leigod.7z\" \"$dir\"",
+            "Remove-Item \"$dir\\leigod.7z\" -Force",
+            "Remove-Item \"$dir\\$fname\" -Force"
+        ]
+    },
+    "uninstaller": {
+        "script": "Remove-Item \"$dir\" -Recurse -Force -ErrorAction SilentlyContinue"
+    },
+    "shortcuts": [
+        [
+            "leigod.exe",
+            "LeiGod"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.leigod.com/",
+        "regex": "win7/8/10/11[^V]*V([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://update.leigod.com/soft/leigod/win/$majorVersion.0.0.0/LeiGodSetup.$version.exe"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #592

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

## Description

Add manifest for LeiGod (雷神加速器), a game accelerator for reducing latency in online games.

- Extracts embedded 7z archive from the installer since silent installation is not supported
- Includes autoupdate functionality
- Proprietary software with over 100 million users in China

## Motivation and Context

LeiGod is a widely used game accelerator in China that requires network driver installation (TAP/WFP), making it suitable for the Nonportable bucket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LeiGod game accelerator package — users can install/manage a latency-reduction tool via the package manager.
  * Includes automatic update checks, direct installer download support, installation of app files and desktop shortcut, and a silent/uninstall option for clean removal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScoopInstaller/Nonportable/pull/593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->