### PR TITLE
files-np@4.1.1.0: Fix download & autoupdate URLs

### DIFF
--- a/bucket/files-np.json
+++ b/bucket/files-np.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.files.community/files/stable/stable/Files.Package_4.1.1.0_Test/Files.Package_4.1.1.0_x64_arm64.msixbundle",
+            "url": "https://cdn.files.community/files/stable/Files.Package_4.1.1.0_Test/Files.Package_4.1.1.0_x64_arm64.msixbundle",
             "hash": "7ffb6e6861d8338329679c0c20d4f896ea73864b6f12b283081e643f4bb9bbf5"
         }
     },
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn.files.community/files/stable/stable/Files.Package_$version_Test/Files.Package_$version_x64_arm64.msixbundle"
+                "url": "https://cdn.files.community/files/stable/Files.Package_$version_Test/Files.Package_$version_x64_arm64.msixbundle"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


The most recent change double the `stable/` in the URL, breaking the manifest


Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected download URLs to resolve path inconsistencies and ensure reliable access to software packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->