### PR TITLE
innosetup-np@6.7.3: Fix download & autoupdate URLs

### DIFF
--- a/bucket/innosetup-np.json
+++ b/bucket/innosetup-np.json
@@ -1,8 +1,11 @@
 {
     "version": "6.7.3",
-    "description": "Installer for Windows programs.",
-    "homepage": "https://jrsoftware.org/isinfo.php",
-    "license": "https://jrsoftware.org/files/is/license.txt",
+    "description": "An open-source installation builder for Windows applications.",
+    "homepage": "https://www.jrsoftware.org/isinfo.php",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.jrsoftware.org/files/is/license.txt"
+    },
     "url": "https://github.com/jrsoftware/issrc/releases/download/is-6_7_3/innosetup-6.7.3.exe",
     "hash": "9c73c3bae7ed48d44112a0f48e66742c00090bdb5bef71d9d3c056c66e97b732",
     "installer": {
@@ -27,6 +30,10 @@
         "regex": "innosetup-([\\d.]+)\\.exe"
     },
     "autoupdate": {
-        "url": "https://github.com/jrsoftware/issrc/releases/download/is-$underscoreVersion/innosetup-$version.exe"
+        "url": "https://github.com/jrsoftware/issrc/releases/download/is-$underscoreVersion/innosetup-$version.exe",
+        "hash": {
+            "url": "https://github.com/jrsoftware/issrc/releases/download/is-$underscoreVersion/innosetup-$version.exe.issig",
+            "regex": "file-hash\\s+$sha256"
+        }
     }
 }

--- a/bucket/innosetup-np.json
+++ b/bucket/innosetup-np.json
@@ -1,23 +1,15 @@
 {
     "version": "6.7.3",
     "description": "Installer for Windows programs.",
-    "homepage": "http://www.jrsoftware.org/isinfo.php",
-    "license": "http://www.jrsoftware.org/files/is/license.txt",
-    "url": "http://www.jrsoftware.org/download.php/is.exe#innosetup-6.7.3.exe",
-    "hash": "4d11e8050b6185e0d49bd9e8cc661a7a59f44959a621d31d11033124c4e8a7b0",
+    "homepage": "https://jrsoftware.org/isinfo.php",
+    "license": "https://jrsoftware.org/files/is/license.txt",
+    "url": "https://github.com/jrsoftware/issrc/releases/download/is-6_7_3/innosetup-6.7.3.exe",
+    "hash": "9c73c3bae7ed48d44112a0f48e66742c00090bdb5bef71d9d3c056c66e97b732",
     "installer": {
         "script": [
             "$args = @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/ALLUSERS', '/NORESTART', '/NOICONS', \"/DIR=`\"$dir`\"\")",
             "Start-Process \"$dir\\$fname\" -ArgumentList $args -Wait -Verb RunAs",
             "Remove-Item \"$dir\\$fname\""
-        ],
-        "#args": [
-            "/VERYSILENT",
-            "/SUPPRESSMSGBOXES",
-            "/ALLUSERS",
-            "/NORESTART",
-            "/NOICONS",
-            "/DIR=\"$dir\""
         ]
     },
     "uninstaller": {
@@ -31,10 +23,10 @@
         ]
     ],
     "checkver": {
-        "url": "http://www.jrsoftware.org/isdl.php",
+        "url": "https://jrsoftware.org/isdl.php",
         "regex": "innosetup-([\\d.]+)\\.exe"
     },
     "autoupdate": {
-        "url": "http://www.jrsoftware.org/download.php/is.exe#innosetup-$version.exe"
+        "url": "https://github.com/jrsoftware/issrc/releases/download/is-$underscoreVersion/innosetup-$version.exe"
     }
 }


### PR DESCRIPTION
## Summary

- replace the HTML download-page redirect with the official versioned GitHub release asset and verified SHA-256
- update the autoupdate template and remaining vendor pages to HTTPS
- remove the unsupported legacy `installer.#args` property so the manifest passes the current schema

## Validation

- `checkver`: 6.7.3
- `checkhashes`: OK
- forced autoupdate regenerated the same URL and SHA-256
- bucket tests: 138/138 on Windows PowerShell 5.1 and PowerShell 7.6.4
- isolated current-user install, compiler, and uninstall smoke test: passed

Closes #618

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
