### PR TITLE
files-np: Update to version 4.2.3.0

### DIFF
--- a/bucket/files-np.json
+++ b/bucket/files-np.json
@@ -1,12 +1,12 @@
 {
-    "version": "4.2.0.0",
+    "version": "4.2.3.0",
     "homepage": "https://files.community",
     "description": "A modern file manager that helps users organize their files and folders.",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.files.community/files/stable/Files.Package_4.2.0.0_Test/Files.Package_4.2.0.0_x64_arm64.msixbundle",
-            "hash": "bfac7288b2d09fd5b70441f5763ad8c341e78b2d8b1698993f4fb7b785fdc758"
+            "url": "https://cdn.files.community/files/stable/Files.Package_4.2.3.0_Test/Files.Package_4.2.3.0_x64_arm64.msixbundle",            
+            "hash": "303118b16eaf97315aa65ac1bb7cf1184062a60b1ee2b833fc8256348edc5c2f"
         }
     },
     "installer": {


### PR DESCRIPTION
official address: https://files.community/blog/posts/v4-2-3

Today we are releasing Files v4.2.3 for all users.

An update icon should be displayed in the top right corner of the app for existing users, while new users can get started from our [download](https://files.community/download/) page. Additionally, you can help support the project by purchasing Files on the [Microsoft Store](ms-windows-store://pdp/?ProductId=9nghp3dx8hdx&cid=FilesWebsite) or by sponsoring us on [GitHub](https://files.community/sponsor). Your support is greatly appreciated but entirely optional.

What’s New in Files v4.2.3
Updated status bar design
The status bar at the bottom of the window has been redesigned for a cleaner, more modern look that fits in better with the rest of the app.

![StatusBar.webp](https://files.community/blog-resources/v4-2-3/StatusBar.webp)

The redesigned status bar
Toggle states for toolbar buttons
Toolbar buttons that turn an option on or off now show a clear toggle state, making it easier to see at a glance which options are currently active.

Convert images to icons for folder icons
When choosing a custom icon in a folder’s Properties, you can now select a .png image and Files will automatically convert it to an .ico file for you.

Choose an encoding when browsing archives
Files now lets you pick the encoding when browsing archives whose filenames aren’t stored in UTF-8, so items inside ZIP archives created on other systems display with the correct names.

Fixes
Fixed an issue where the permanently delete checkbox was not shown in the delete dialog.
Conclusion
As always, we appreciate your feedback and suggestions on how to improve Files. You can reach us on [Discord](https://discord.gg/files) and on [GitHub](https://github.com/files-community/Files/).

Thank you for using Files! 😊