### PR TITLE
moogh-np: Add version 2026.9.11-1

### DIFF
--- a/bucket/moogh-np.json
+++ b/bucket/moogh-np.json
@@ -1,0 +1,47 @@
+{
+    "version": "2026.9.11-1",
+    "description": "AI agent desktop client that plans and completes local computer work on Windows.",
+    "homepage": "https://www.aimoogh.com/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://agent.aimoogh.com/terms.html"
+    },
+    "notes": [
+        "MOOGH installs per-user by default; admin rights are only required for a machine-wide install.",
+        "Official download page: https://agent.aimoogh.com/download",
+        "Privacy policy: https://agent.aimoogh.com/privacy.html"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://down.aimoogh.com/downloads/win/stable/2026.9.11-1/moogh-win-x64-2026.9.11-1.exe#/moogh-setup.exe",
+            "hash": "2E94E6326F29F6EAD60E1A8354D591D56578CC423220EB6A370694282B5931BF"
+        }
+    },
+    "installer": {
+        "script": [
+            "Start-Process \"$dir\\moogh-setup.exe\" -ArgumentList @('/S', \"/D=$dir\") -Wait | Out-Null",
+            "Remove-Item \"$dir\\moogh-setup.exe\""
+        ]
+    },
+    "uninstaller": {
+        "script": "Get-ItemProperty \"HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*\" | Where-Object { $_.DisplayName -like 'MOOGH*' } | ForEach-Object { Start-Process $_.UninstallString -ArgumentList '/S' -Wait | Out-Null }"
+    },
+    "bin": "MOOGH.exe",
+    "shortcuts": [
+        [
+            "MOOGH.exe",
+            "MOOGH"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.aimoogh.com/en/download/",
+        "regex": "Download MOOGH v([\\d.]+-\\d+) for Windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://down.aimoogh.com/downloads/win/stable/$version/moogh-win-x64-$version.exe#/moogh-setup.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new manifest for MOOGH, an AI agent desktop client for Windows 10/11 (x64).

- Bucket: nonportable (the installer is an electron-builder NSIS package that writes uninstall registry entries, so it is not portable)
- Manifest: bucket/moogh-np.json
- Version: 2026.9.11-1
- Installer SHA-256: 2E94E6326F29F6EAD60E1A8354D591D56578CC423220EB6A370694282B5931BF
- Installer size: 255,706,720 bytes (243.9 MB)
- Authenticode signed (Certum Code Signing 2021 CA)

## Notes on the manifest

- installer.script passes /S to the upstream NSIS installer.
- uninstaller.script resolves the per-user uninstall entry from HKCU Software Microsoft Windows CurrentVersion Uninstall and runs it with /S.
- checkver reads the vendor download page, which publishes the current version in a stable phrase: Download MOOGH v{version} for Windows
- autoupdate targets the vendor immutable versioned artifact path: https://down.aimoogh.com/downloads/win/stable/$version/moogh-win-x64-$version.exe

## Testing

Install, functional check and uninstall were exercised on Windows 11 x64 using the signed installer from the URL above. Portable configuration is not applicable to this application.

## Please note

A Package Request issue has not been opened for this manifest. MOOGH is a new application in open testing. The Nonportable bucket criteria expect a reasonably well-known and widely used application, so I am flagging this up front rather than asserting it. I am happy to close this PR and revisit later if that is the maintainers preference.

- [x] I have read the Contributing Guide: https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md